### PR TITLE
Add copychunk support and test cases

### DIFF
--- a/pike/model.py
+++ b/pike/model.py
@@ -1116,6 +1116,40 @@ class Channel(object):
 
         return res
 
+    def resume_key(self, file):
+        smb_req = self.request(obj=file.tree)
+        ioctl_req = smb2.IoctlRequest(smb_req)
+        resumekey_req = smb2.RequestResumeKeyRequest(ioctl_req)
+
+        ioctl_req.file_id = file.file_id
+
+        return self.connection.transceive(smb_req.parent)[0]
+
+    def copychunk(self, source_file, target_file, chunks):
+        """
+        @param source_file: L{Open}
+        @param target_file: L{Open}
+        @param chunks: sequence of tuples (source_offset, target_offset, length)
+        """
+        resume_key = self.resume_key(source_file)[0][0].resume_key
+
+        smb_req = self.request(obj=target_file.tree)
+        ioctl_req = smb2.IoctlRequest(smb_req)
+        copychunk_req = smb2.CopyChunkCopyRequest(ioctl_req)
+
+        ioctl_req.max_output_response = 16384
+        ioctl_req.file_id = target_file.file_id
+        copychunk_req.source_key = resume_key
+        copychunk_req.chunk_count = len(chunks)
+
+        for source_offset, target_offset, length in chunks:
+            chunk = smb2.CopyChunk(copychunk_req)
+            chunk.source_offset = source_offset
+            chunk.target_offset = target_offset
+            chunk.length = length
+
+        return self.connection.transceive(smb_req.parent)[0]
+
     def frame(self):
         return self.connection.frame()
 

--- a/pike/model.py
+++ b/pike/model.py
@@ -1123,6 +1123,7 @@ class Channel(object):
         resumekey_req = smb2.RequestResumeKeyRequest(ioctl_req)
 
         ioctl_req.file_id = file.file_id
+        ioctl_req.flags |= smb2.SMB2_0_IOCTL_IS_FSCTL
 
         return self.connection.transceive(smb_req.parent)[0]
 
@@ -1140,6 +1141,7 @@ class Channel(object):
 
         ioctl_req.max_output_response = 16384
         ioctl_req.file_id = target_file.file_id
+        ioctl_req.flags |= smb2.SMB2_0_IOCTL_IS_FSCTL
         copychunk_req.source_key = resume_key
         copychunk_req.chunk_count = len(chunks)
 

--- a/pike/model.py
+++ b/pike/model.py
@@ -606,7 +606,8 @@ class Connection(asyncore.dispatcher):
                 future = self._future_map[smb_res.message_id]
                 if smb_res.status == ntstatus.STATUS_PENDING:
                     future.interim(smb_res)
-                elif isinstance(smb_res[0], smb2.ErrorResponse):
+                elif isinstance(smb_res[0], smb2.ErrorResponse) or \
+                     smb_res.status not in smb_res[0].allowed_status:
                     future.complete(ResponseError(smb_res))
                     del self._future_map[smb_res.message_id]
                 else:

--- a/pike/smb2.py
+++ b/pike/smb2.py
@@ -2986,6 +2986,50 @@ class ValidateNegotiateInfoRequest(IoctlInput):
         for dialect in self.dialects:
             cur.encode_uint16le(dialect)
 
+class RequestResumeKeyRequest(IoctlInput):
+    ioctl_ctl_code = FSCTL_SRV_REQUEST_RESUME_KEY
+
+    def __init__(self, parent):
+        IoctlInput.__init__(self, parent)
+        parent.ioctl_input = self
+
+    def  _encode(self, cur):
+        pass
+
+class CopyChunkCopyRequest(IoctlInput):
+    ioctl_ctl_code = FSCTL_SRV_COPYCHUNK
+
+    def __init__(self, parent):
+        IoctlInput.__init__(self, parent)
+        self.source_key = 0
+        self.chunk_count = 0
+        self._children = []
+
+    def append(self, child):
+        self._children.append(child)
+
+    def  _encode(self, cur):
+        cur.encode_bytes(self.source_key)
+        cur.encode_uint32le(self.chunk_count)
+        cur.encode_uint32le(0)                          # reserved
+        #encode the chunks
+        for chunk in self._children:
+            chunk.encode(cur)
+
+class CopyChunk(core.Frame):
+    def __init__(self, parent):
+        core.Frame.__init__(self, parent)
+        parent.append(self)
+        self.source_offset = 0
+        self.target_offset = 0
+        self.length = 0
+
+    def _encode(self, cur):
+        cur.encode_uint64le(self.source_offset)
+        cur.encode_uint64le(self.target_offset)
+        cur.encode_uint32le(self.length)
+        cur.encode_uint32le(0)
+
 @IoctlResponse.ioctl_ctl_code
 class IoctlOutput(core.Frame):
     def __init__(self, parent):
@@ -3008,3 +3052,29 @@ class ValidateNegotiateInfoResponse(IoctlOutput):
         self.client_guid = cur.decode_bytes(16)
         self.security_mode = SecurityMode(cur.decode_uint16le())
         self.dialect = Dialect(cur.decode_uint16le())
+
+class RequestResumeKeyResponse(IoctlOutput):
+   ioctl_ctl_code = FSCTL_SRV_REQUEST_RESUME_KEY
+
+   def __init__(self, parent):
+        IoctlOutput.__init__(self, parent)
+        self.resume_key = array.array('B',[0]*24)
+        self.context_length = 0
+
+   def _decode(self, cur):
+        self.resume_key = cur.decode_bytes(24)
+        self.context_length = cur.decode_uint32le()
+
+class CopyChunkCopyResponse(IoctlOutput):
+   ioctl_ctl_code = FSCTL_SRV_COPYCHUNK
+
+   def __init__(self, parent):
+        IoctlOutput.__init__(self, parent)
+        self.chunks_written = 0
+        self.chunk_bytes_written = 0
+        self.total_bytes_written = 0
+
+   def _decode(self, cur):
+        self.chunks_written = cur.decode_uint32le()
+        self.chunk_bytes_written = cur.decode_uint32le()
+        self.total_bytes_written = cur.decode_uint32le()

--- a/pike/smb2.py
+++ b/pike/smb2.py
@@ -249,7 +249,8 @@ class Smb2(core.Frame):
                     raise core.BadPacket()
             elif key in Smb2._response_table:
                 cls = Smb2._response_table[key]
-                if self.status not in cls.allowed_status:
+                if self.status not in cls.allowed_status and \
+                   structure_size == ErrorResponse.structure_size:
                     cls = ErrorResponse
             else:
                 cls = ErrorResponse

--- a/pike/test.py
+++ b/pike/test.py
@@ -190,6 +190,28 @@ class PikeTest(unittest.TestCase):
 
     def required_share_capabilities(self):
         return self._get_decorator_attr('RequireShareCapabilities', 0)
+
+    def assertBufferEqual(self, buf1, buf2):
+        """
+        Compare two sequences using a binary diff to efficiently determine 
+        the first offset where they differ
+        """
+        if len(buf1) != len(buf2):
+            raise AssertionError("Buffers are not the same size")
+        low = 0
+        high = len(buf1)
+        while high - low > 1:
+            chunk_1 = (low, low+(high-low)/2)
+            chunk_2 = (low+(high-low)/2, high)
+            if buf1[chunk_1[0]:chunk_1[1]] != buf2[chunk_1[0]:chunk_1[1]]:
+                low, high = chunk_1
+            elif buf1[chunk_2[0]:chunk_2[1]] != buf2[chunk_2[0]:chunk_2[1]]:
+                low, high = chunk_2
+            else:
+                break
+        if high - low <= 1:
+            raise AssertionError("Block mismatch at byte {0}: "
+                                 "{1} != {2}".format(low, buf1[low], buf2[low]))
         
 class _Decorator(object):
     def __init__(self, value):

--- a/test/copychunk.py
+++ b/test/copychunk.py
@@ -62,49 +62,68 @@ def _gen_test_buffer(length):
 ###
 class TestServerSideCopy(pike.test.PikeTest):
 
-    def _create_and_write(self, chan, tree, filename, content):
+    def setUp(self):
+        self.chan, self.tree = self.tree_connect()
+
+    def tearDown(self):
+        self.chan.tree_disconnect(self.tree)
+        self.chan.logoff()
+
+    def _create_and_write(self, filename, content):
         """ create / overwrite filename with content """
-        fh1 =     chan.create(tree,
-                              filename,
-                              access=access_rwd,
-                              share=share_all,
-                              disposition=pike.smb2.FILE_SUPERSEDE).result()
+        fh1 = self.chan.create(self.tree,
+                               filename,
+                               access=access_rwd,
+                               share=share_all,
+                               disposition=pike.smb2.FILE_SUPERSEDE).result()
 
-        bytes_written = chan.write(fh1,
-                                   0,
-                                   content)
-        chan.close(fh1)
+        bytes_written = self.chan.write(fh1, 0, content)
+        self.chan.close(fh1)
 
-    def _open_src_dst(self, chan, tree, src_filename, dst_filename,
-                      src_disp=pike.smb2.FILE_OPEN,
-                      dst_disp=pike.smb2.FILE_SUPERSEDE):
+    def _open_src_dst(self, src_filename, dst_filename,
+                      src_access=None,
+                      src_disp=None,
+                      src_options=None,
+                      dst_access=None,
+                      dst_disp=None,
+                      dst_options=None):
+        if src_access is None:
+            src_access = pike.smb2.FILE_READ_DATA | pike.smb2.DELETE
+        if dst_access is None:
+            dst_access = access_rwd
+        if src_disp is None:
+            src_disp = pike.smb2.FILE_OPEN
+        if dst_disp is None:
+            dst_disp = pike.smb2.FILE_SUPERSEDE
+        if src_options is None:
+            src_options = pike.smb2.FILE_DELETE_ON_CLOSE
+        if dst_options is None:
+            dst_options = pike.smb2.FILE_DELETE_ON_CLOSE
 
-        src_options = dst_options = pike.smb2.FILE_DELETE_ON_CLOSE
         if src_filename == dst_filename:
             src_options = 0     # if we're opening the same file, only delete one
-        fh_src = chan.create(tree,
-                             src_filename,
-                             access=access_rwd,
-                             share=share_all,
-                             disposition=src_disp,
-                             options=src_options).result()
+        fh_src = self.chan.create(self.tree,
+                                  src_filename,
+                                  access=src_access,
+                                  share=share_all,
+                                  disposition=src_disp,
+                                  options=src_options).result()
 
-        fh_dst = chan.create(tree,
-                             dst_filename,
-                             access=access_rwd,
-                             share=share_all,
-                             disposition=dst_disp,
-                             options=dst_options).result()
+        fh_dst = self.chan.create(self.tree,
+                                  dst_filename,
+                                  access=dst_access,
+                                  share=share_all,
+                                  disposition=dst_disp,
+                                  options=dst_options).result()
         return (fh_src, fh_dst)
 
     def generic_ssc_test_case(self, block, number_of_chunks, total_offset=0):
         """
         copy block in number_of_chunks, offset the destination copy by total_offset
         """
-        chan, tree = self.tree_connect()
         src_filename = "src_copy_chunk_offset.txt"
         dst_filename = "dst_copy_chunk_offset.txt"
-        self._create_and_write(chan, tree, src_filename, block)
+        self._create_and_write(src_filename, block)
 
         total_len = len(block)
         chunk_sz = (total_len / number_of_chunks) + 1
@@ -120,17 +139,20 @@ class TestServerSideCopy(pike.test.PikeTest):
             chunks.append((offset, offset+total_offset, length))
             this_offset += chunk_sz
 
-        fh_src, fh_dst = self._open_src_dst(chan, tree, src_filename, dst_filename)
+        fh_src, fh_dst = self._open_src_dst(src_filename, dst_filename)
 
-        result = chan.copychunk(fh_src, fh_dst, chunks)
+        result = self.chan.copychunk(fh_src, fh_dst, chunks)
         self.assertEqual(result[0][0].chunks_written, number_of_chunks)
         self.assertEqual(result[0][0].total_bytes_written, total_len)
 
         # read each file and verify the result
-        src_buf = chan.read(fh_src, total_len, 0).tostring()
-        self.assertEqual(src_buf, block)
-        dst_buf = chan.read(fh_dst, total_len, total_offset).tostring()
-        self.assertEqual(dst_buf, block)
+        src_buf = self.chan.read(fh_src, total_len, 0).tostring()
+        self.assertBufferEqual(src_buf, block)
+        dst_buf = self.chan.read(fh_dst, total_len, total_offset).tostring()
+        self.assertBufferEqual(dst_buf, block)
+
+        self.chan.close(fh_src)
+        self.chan.close(fh_dst)
 
     def test_copy_small_file(self):
         block = "Hello"
@@ -175,9 +197,8 @@ class TestServerSideCopy(pike.test.PikeTest):
         duplicate block in number_of_chunks to the same file,
         the copy will be total_offset from the current end of file
         """
-        chan, tree = self.tree_connect()
         filename = "src_copy_chunk_same.txt"
-        self._create_and_write(chan, tree, filename, block)
+        self._create_and_write(filename, block)
 
         total_len = len(block)
         chunk_sz = (total_len / number_of_chunks) + 1
@@ -193,19 +214,24 @@ class TestServerSideCopy(pike.test.PikeTest):
             chunks.append((offset, offset+total_len+total_offset, length))
             this_offset += chunk_sz
 
-        fh_src, fh_dst = self._open_src_dst(chan, tree, filename, filename,
+        fh_src, fh_dst = self._open_src_dst(filename, filename,
                                             dst_disp=pike.smb2.FILE_OPEN_IF)
 
-        result = chan.copychunk(fh_src, fh_dst, chunks)
+        result = self.chan.copychunk(fh_src, fh_dst, chunks)
         self.assertEqual(result[0][0].chunks_written, number_of_chunks)
         self.assertEqual(result[0][0].total_bytes_written, total_len)
 
         # read the file and verify the result
-        src_buf = chan.read(fh_src, total_len*2+total_offset, 0).tostring()
-        self.assertEqual(src_buf[:total_len], block)
-        self.assertEqual(src_buf[total_len:total_len+total_offset],
-                         "\x00"*total_offset)
-        self.assertEqual(src_buf[total_len+total_offset:], block)
+        src_buf = self.chan.read(fh_src, total_len, 0).tostring()
+        self.assertBufferEqual(src_buf, block)
+        if total_offset > 0:
+            offs_buf = self.chan.read(fh_src, total_offset, total_len).tostring()
+            self.assertBufferEqual(offs_buf, "\x00"*total_offset)
+        dst_buf = self.chan.read(fh_src, total_len, total_len+total_offset).tostring()
+        self.assertBufferEqual(dst_buf, block)
+
+        self.chan.close(fh_src)
+        self.chan.close(fh_dst)
 
     def test_same_small_file(self):
         block = "Hello"
@@ -245,10 +271,9 @@ class TestServerSideCopy(pike.test.PikeTest):
         copy block in number_of_chunks, each destination block offset will be overlapped
         over the previous block by overlap_each_block bytes
         """
-        chan, tree = self.tree_connect()
         src_filename = "src_copy_chunk_overlap.txt"
         dst_filename = "dst_copy_chunk_overlap.txt"
-        self._create_and_write(chan, tree, src_filename, block)
+        self._create_and_write(src_filename, block)
 
         total_len = len(block)
         chunk_sz = (total_len / number_of_chunks) + 1
@@ -269,23 +294,23 @@ class TestServerSideCopy(pike.test.PikeTest):
             dst_block[dst_offset:dst_offset+length] = \
                     src_block[offset:offset+length]
             this_offset += chunk_sz
-        if len(chunks) == 14:
-            print(chunk_sz)
-            print(total_len)
-            print(chunks)
+        dst_len = dst_offset+length
+        dst_block = "".join(dst_block[:dst_len])
 
-        fh_src, fh_dst = self._open_src_dst(chan, tree, src_filename, dst_filename)
+        fh_src, fh_dst = self._open_src_dst(src_filename, dst_filename)
 
-        result = chan.copychunk(fh_src, fh_dst, chunks)
+        result = self.chan.copychunk(fh_src, fh_dst, chunks)
         self.assertEqual(result[0][0].chunks_written, number_of_chunks)
         self.assertEqual(result[0][0].total_bytes_written, total_len)
 
         # read each file and verify the result
-        src_buf = chan.read(fh_src, total_len, 0).tostring()
-        self.assertEqual(src_buf, block)
-        dst_len = chunks[-1][1]+chunks[-1][2]
-        dst_buf = chan.read(fh_dst, dst_len, 0).tostring()
-        self.assertEqual(dst_buf, "".join(dst_block[:dst_len]))
+        src_buf = self.chan.read(fh_src, total_len, 0).tostring()
+        self.assertBufferEqual(src_buf, block)
+        dst_buf = self.chan.read(fh_dst, dst_len, 0).tostring()
+        self.assertBufferEqual(dst_buf, dst_block)
+
+        self.chan.close(fh_src)
+        self.chan.close(fh_dst)
 
     def test_overlap_multiple_chunks(self):
         block = _gen_test_buffer(65535)

--- a/test/copychunk.py
+++ b/test/copychunk.py
@@ -1,0 +1,306 @@
+#
+# Copyright (c) 2015, EMC Corporation
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# Module Name:
+#
+#        copychunk.py
+#
+# Abstract:
+#
+#        Tests for server side copy
+#
+# Authors: Avi Bhandari (avi.bahndari@emc.com)
+#          Masen Furer (masen.furer@emc.com)
+#
+
+import pike.ntstatus
+import pike.smb2
+import pike.test
+
+share_all = pike.smb2.FILE_SHARE_READ | \
+            pike.smb2.FILE_SHARE_WRITE | \
+            pike.smb2.FILE_SHARE_DELETE
+access_rwd = pike.smb2.FILE_READ_DATA | \
+             pike.smb2.FILE_WRITE_DATA | \
+             pike.smb2.DELETE
+
+# Max values
+
+SERVER_SIDE_COPY_MAX_NUMBER_OF_CHUNKS = 16
+SERVER_SIDE_COPY_MAX_CHUNK_SIZE = 1048576
+SERVER_SIDE_COPY_MAX_DATA_SIZE = 16777216
+
+def _gen_test_buffer(length):
+    pattern = "".join([ chr(x) for x in xrange(ord(' '), ord('~'))])
+    buf = (pattern * (length / (len(pattern)) + 1))[:length]
+    return buf
+
+###
+# Main test
+###
+class TestServerSideCopy(pike.test.PikeTest):
+
+    def _create_and_write(self, chan, tree, filename, content):
+        """ create / overwrite filename with content """
+        fh1 =     chan.create(tree,
+                              filename,
+                              access=access_rwd,
+                              share=share_all,
+                              disposition=pike.smb2.FILE_SUPERSEDE).result()
+
+        bytes_written = chan.write(fh1,
+                                   0,
+                                   content)
+        chan.close(fh1)
+
+    def _open_src_dst(self, chan, tree, src_filename, dst_filename,
+                      src_disp=pike.smb2.FILE_OPEN,
+                      dst_disp=pike.smb2.FILE_SUPERSEDE):
+
+        src_options = dst_options = pike.smb2.FILE_DELETE_ON_CLOSE
+        if src_filename == dst_filename:
+            src_options = 0     # if we're opening the same file, only delete one
+        fh_src = chan.create(tree,
+                             src_filename,
+                             access=access_rwd,
+                             share=share_all,
+                             disposition=src_disp,
+                             options=src_options).result()
+
+        fh_dst = chan.create(tree,
+                             dst_filename,
+                             access=access_rwd,
+                             share=share_all,
+                             disposition=dst_disp,
+                             options=dst_options).result()
+        return (fh_src, fh_dst)
+
+    def generic_ssc_test_case(self, block, number_of_chunks, total_offset=0):
+        """
+        copy block in number_of_chunks, offset the destination copy by total_offset
+        """
+        chan, tree = self.tree_connect()
+        src_filename = "src_copy_chunk_offset.txt"
+        dst_filename = "dst_copy_chunk_offset.txt"
+        self._create_and_write(chan, tree, src_filename, block)
+
+        total_len = len(block)
+        chunk_sz = (total_len / number_of_chunks) + 1
+        this_offset = 0
+
+        chunks = []
+        while this_offset < total_len:
+            offset = this_offset
+            if this_offset + chunk_sz < total_len:
+                length = chunk_sz
+            else:
+                length = total_len - this_offset
+            chunks.append((offset, offset+total_offset, length))
+            this_offset += chunk_sz
+
+        fh_src, fh_dst = self._open_src_dst(chan, tree, src_filename, dst_filename)
+
+        result = chan.copychunk(fh_src, fh_dst, chunks)
+        self.assertEqual(result[0][0].chunks_written, number_of_chunks)
+        self.assertEqual(result[0][0].total_bytes_written, total_len)
+
+        # read each file and verify the result
+        src_buf = chan.read(fh_src, total_len, 0).tostring()
+        self.assertEqual(src_buf, block)
+        dst_buf = chan.read(fh_dst, total_len, total_offset).tostring()
+        self.assertEqual(dst_buf, block)
+
+    def test_copy_small_file(self):
+        block = "Hello"
+        num_of_chunks = 1
+        self.generic_ssc_test_case(block, num_of_chunks)
+
+    def test_copy_big_file(self):
+        block = _gen_test_buffer(65535)
+        num_of_chunks = 1
+        self.generic_ssc_test_case(block, num_of_chunks)
+
+    def test_copy_multiple_chunks(self):
+        block = _gen_test_buffer(65535)
+        num_of_chunks = 10
+        self.generic_ssc_test_case(block, num_of_chunks)
+
+    def test_copy_max_chunks(self):
+        block = _gen_test_buffer(65535)
+        num_of_chunks = 16
+        self.generic_ssc_test_case(block, num_of_chunks)
+
+    def test_offset_copy_small_file(self):
+        block = "Hello"
+        num_of_chunks = 1
+        offset = 64
+        self.generic_ssc_test_case(block, num_of_chunks, offset)
+
+    def test_offset_copy_big_file(self):
+        block = _gen_test_buffer(65535)
+        num_of_chunks = 1
+        offset = 64
+        self.generic_ssc_test_case(block, num_of_chunks, offset)
+
+    def test_offset_copy_multiple_chunks(self):
+        block = _gen_test_buffer(65535)
+        num_of_chunks = 10
+        offset = 64
+        self.generic_ssc_test_case(block, num_of_chunks, offset)
+
+    def generic_ssc_same_file_test_case(self, block, number_of_chunks, total_offset=0):
+        """
+        duplicate block in number_of_chunks to the same file,
+        the copy will be total_offset from the current end of file
+        """
+        chan, tree = self.tree_connect()
+        filename = "src_copy_chunk_same.txt"
+        self._create_and_write(chan, tree, filename, block)
+
+        total_len = len(block)
+        chunk_sz = (total_len / number_of_chunks) + 1
+        this_offset = 0
+
+        chunks = []
+        while this_offset < total_len:
+            offset = this_offset
+            if this_offset + chunk_sz < total_len:
+                length = chunk_sz
+            else:
+                length = total_len - this_offset
+            chunks.append((offset, offset+total_len+total_offset, length))
+            this_offset += chunk_sz
+
+        fh_src, fh_dst = self._open_src_dst(chan, tree, filename, filename,
+                                            dst_disp=pike.smb2.FILE_OPEN_IF)
+
+        result = chan.copychunk(fh_src, fh_dst, chunks)
+        self.assertEqual(result[0][0].chunks_written, number_of_chunks)
+        self.assertEqual(result[0][0].total_bytes_written, total_len)
+
+        # read the file and verify the result
+        src_buf = chan.read(fh_src, total_len*2+total_offset, 0).tostring()
+        self.assertEqual(src_buf[:total_len], block)
+        self.assertEqual(src_buf[total_len:total_len+total_offset],
+                         "\x00"*total_offset)
+        self.assertEqual(src_buf[total_len+total_offset:], block)
+
+    def test_same_small_file(self):
+        block = "Hello"
+        num_of_chunks = 1
+        self.generic_ssc_same_file_test_case(block, num_of_chunks)
+
+    def test_same_big_file(self):
+        block = _gen_test_buffer(65535)
+        num_of_chunks = 1
+        self.generic_ssc_same_file_test_case(block, num_of_chunks)
+
+    def test_same_multiple_chunks(self):
+        block = _gen_test_buffer(65535)
+        num_of_chunks = 10
+        self.generic_ssc_same_file_test_case(block, num_of_chunks)
+
+    def test_same_offset_small_file(self):
+        block = "Hello"
+        num_of_chunks = 1
+        offset = 64
+        self.generic_ssc_same_file_test_case(block, num_of_chunks, offset)
+
+    def test_same_offset_big_file(self):
+        block = _gen_test_buffer(65535)
+        num_of_chunks = 1
+        offset = 64
+        self.generic_ssc_same_file_test_case(block, num_of_chunks, offset)
+
+    def test_same_offset_multiple_chunks(self):
+        block = _gen_test_buffer(65535)
+        num_of_chunks = 10
+        offset = 64
+        self.generic_ssc_same_file_test_case(block, num_of_chunks, offset)
+
+    def generic_ssc_overlap_test_case(self, block, number_of_chunks, overlap_each_block=0):
+        """
+        copy block in number_of_chunks, each destination block offset will be overlapped
+        over the previous block by overlap_each_block bytes
+        """
+        chan, tree = self.tree_connect()
+        src_filename = "src_copy_chunk_overlap.txt"
+        dst_filename = "dst_copy_chunk_overlap.txt"
+        self._create_and_write(chan, tree, src_filename, block)
+
+        total_len = len(block)
+        chunk_sz = (total_len / number_of_chunks) + 1
+        this_offset = 0
+
+        chunks = []
+        src_block = list(block)
+        dst_block = list(block)
+        while this_offset < total_len:
+            offset = dst_offset = this_offset
+            if offset - overlap_each_block > 0:
+                dst_offset = offset - overlap_each_block
+            if this_offset + chunk_sz < total_len:
+                length = chunk_sz
+            else:
+                length = total_len - this_offset
+            chunks.append((offset, dst_offset, length))
+            dst_block[dst_offset:dst_offset+length] = \
+                    src_block[offset:offset+length]
+            this_offset += chunk_sz
+        if len(chunks) == 14:
+            print(chunk_sz)
+            print(total_len)
+            print(chunks)
+
+        fh_src, fh_dst = self._open_src_dst(chan, tree, src_filename, dst_filename)
+
+        result = chan.copychunk(fh_src, fh_dst, chunks)
+        self.assertEqual(result[0][0].chunks_written, number_of_chunks)
+        self.assertEqual(result[0][0].total_bytes_written, total_len)
+
+        # read each file and verify the result
+        src_buf = chan.read(fh_src, total_len, 0).tostring()
+        self.assertEqual(src_buf, block)
+        dst_len = chunks[-1][1]+chunks[-1][2]
+        dst_buf = chan.read(fh_dst, dst_len, 0).tostring()
+        self.assertEqual(dst_buf, "".join(dst_block[:dst_len]))
+
+    def test_overlap_multiple_chunks(self):
+        block = _gen_test_buffer(65535)
+        num_of_chunks = 10
+        overlap = 64
+        self.generic_ssc_overlap_test_case(block, num_of_chunks, overlap)
+
+    def test_overlap_16_chunks_1024_overlap(self):
+        block = _gen_test_buffer(65535)
+        num_of_chunks = 16
+        overlap = 1024
+        self.generic_ssc_overlap_test_case(block, num_of_chunks, overlap)
+
+    def test_overlap_15_chunks_4096_overlap(self):
+        block = _gen_test_buffer(65535)
+        num_of_chunks = 15
+        overlap = 4096
+        self.generic_ssc_overlap_test_case(block, num_of_chunks, overlap)

--- a/test/copychunk.py
+++ b/test/copychunk.py
@@ -378,18 +378,20 @@ class TestServerSideCopy(pike.test.PikeTest):
             self.chan.close(fh_src)
             self.chan.close(fh_dst)
 
+    @pike.test.RequireDialect(pike.smb2.DIALECT_SMB3_0)
     def test_neg_src_exc_brl(self):
         """
         Initiate copychunk when another handle has an exclusive BRL on the
-        source file
+        source file (win 8 / 2012)
         """
         self.generic_ssc_negative_test_case(src_brl=True,
                                             exp_error=pike.ntstatus.STATUS_FILE_LOCK_CONFLICT)
 
+    @pike.test.RequireDialect(pike.smb2.DIALECT_SMB3_0)
     def test_neg_dst_exc_brl(self):
         """
         Initiate copychunk when another handle has an exclusive BRL on the
-        destination file
+        destination file (win 8 / 2012)
         """
         self.generic_ssc_negative_test_case(dst_brl=True,
                                             exp_error=pike.ntstatus.STATUS_FILE_LOCK_CONFLICT)
@@ -426,24 +428,3 @@ class TestServerSideCopy(pike.test.PikeTest):
                                                         pike.smb2.FILE_DELETE_ON_CLOSE,
                                             dst_disp=pike.smb2.FILE_OPEN_IF,
                                             exp_error=pike.ntstatus.STATUS_INVALID_DEVICE_REQUEST)
-
-    def _test_dst_no_read_copychunk_write(self):
-        """
-        Initiate copychunk_write with no read access on the destination file
-        """
-        pass
-    def _test_neg_named_pipe(self):
-        """
-        Try to copychunk against a named pipe.
-        """
-        pass
-    def _test_neg_different_session(self):
-        """
-        Try to copy chunk across sessions
-        """
-        pass
-    def _test_neg_different_tree(self):
-        """
-        Try to copy chunk across shares
-        """
-        pass


### PR DESCRIPTION
Windows Server 2012r2:

head-11858-1# PYTHONPATH=test unit2 -v copychunk
test_copy_big_file (copychunk.TestServerSideCopy) ... ok
test_copy_max_chunks (copychunk.TestServerSideCopy) ... ok
test_copy_multiple_chunks (copychunk.TestServerSideCopy) ... ok
test_copy_small_file (copychunk.TestServerSideCopy) ... ok
test_neg_dst_exc_brl (copychunk.TestServerSideCopy) ... ok
test_neg_dst_is_a_dir (copychunk.TestServerSideCopy) ... ok
test_neg_dst_no_read (copychunk.TestServerSideCopy) ... ok
test_neg_dst_no_write (copychunk.TestServerSideCopy) ... ok
test_neg_src_exc_brl (copychunk.TestServerSideCopy) ... ok
test_neg_src_no_read (copychunk.TestServerSideCopy) ... ok
test_offset_copy_big_file (copychunk.TestServerSideCopy) ... ok
test_offset_copy_multiple_chunks (copychunk.TestServerSideCopy) ... ok
test_offset_copy_small_file (copychunk.TestServerSideCopy) ... ok
test_overlap_15_chunks_4096_overlap (copychunk.TestServerSideCopy) ... ok
test_overlap_16_chunks_1024_overlap (copychunk.TestServerSideCopy) ... ok
test_overlap_multiple_chunks (copychunk.TestServerSideCopy) ... ok
test_same_big_file (copychunk.TestServerSideCopy) ... ok
test_same_multiple_chunks (copychunk.TestServerSideCopy) ... ok
test_same_offset_big_file (copychunk.TestServerSideCopy) ... ok
test_same_offset_multiple_chunks (copychunk.TestServerSideCopy) ... ok
test_same_offset_small_file (copychunk.TestServerSideCopy) ... ok
test_same_small_file (copychunk.TestServerSideCopy) ... ok

----------------------------------------------------------------------
Ran 22 tests in 1.638s

OK

Windows Server 2008r2:
head-11858-1# PYTHONPATH=test unit2 -v copychunk
test_copy_big_file (copychunk.TestServerSideCopy) ... ok
test_copy_max_chunks (copychunk.TestServerSideCopy) ... ok
test_copy_multiple_chunks (copychunk.TestServerSideCopy) ... ok
test_copy_small_file (copychunk.TestServerSideCopy) ... ok
test_neg_dst_exc_brl (copychunk.TestServerSideCopy) ... skipped 'Dialect required: DIALECT_SMB3_0'
test_neg_dst_is_a_dir (copychunk.TestServerSideCopy) ... ok
test_neg_dst_no_read (copychunk.TestServerSideCopy) ... ok
test_neg_dst_no_write (copychunk.TestServerSideCopy) ... ok
test_neg_src_exc_brl (copychunk.TestServerSideCopy) ... skipped 'Dialect required: DIALECT_SMB3_0'
test_neg_src_no_read (copychunk.TestServerSideCopy) ... ok
test_offset_copy_big_file (copychunk.TestServerSideCopy) ... ok
test_offset_copy_multiple_chunks (copychunk.TestServerSideCopy) ... ok
test_offset_copy_small_file (copychunk.TestServerSideCopy) ... ok
test_overlap_15_chunks_4096_overlap (copychunk.TestServerSideCopy) ... ok
test_overlap_16_chunks_1024_overlap (copychunk.TestServerSideCopy) ... ok
test_overlap_multiple_chunks (copychunk.TestServerSideCopy) ... ok
test_same_big_file (copychunk.TestServerSideCopy) ... ok
test_same_multiple_chunks (copychunk.TestServerSideCopy) ... ok
test_same_offset_big_file (copychunk.TestServerSideCopy) ... ok
test_same_offset_multiple_chunks (copychunk.TestServerSideCopy) ... ok
test_same_offset_small_file (copychunk.TestServerSideCopy) ... ok
test_same_small_file (copychunk.TestServerSideCopy) ... ok

----------------------------------------------------------------------
Ran 22 tests in 37.352s

OK (skipped=2)