### PR TITLE
Integrate version 0.2.4

### DIFF
--- a/pike/netbios.py
+++ b/pike/netbios.py
@@ -41,7 +41,7 @@ import smb2
 class Netbios(core.Frame):
     def __init__(self, context=None):
         core.Frame.__init__(self, None, context)
-        self.len = 0
+        self.len = None
         self.conn = context
         self.transform = None
         self._smb2_frames = []
@@ -60,7 +60,8 @@ class Netbios(core.Frame):
             for child in self.children:
                 child.encode(cur)
 
-        self.len = cur - base
+        if self.len is None:
+            self.len = cur - base
         len_hole(self.len)
 
     def _decode(self, cur):

--- a/pike/nttime.py
+++ b/pike/nttime.py
@@ -55,10 +55,22 @@ def _nt_time_to_unix_time(t):
     result = (t / _intervals_per_second) - _unix_time_offset
     return result if result >= 0 else 0
 
+def GMT_to_datetime(gmt_token):
+    dt_obj = datetime.strptime(
+            gmt_token,
+            "@GMT-%Y.%m.%d-%H.%M.%S")
+    # apply timezone conversion
+    dt_obj -= timedelta(seconds=time.timezone)
+    return dt_obj
+
 class NtTime(long):
     def __new__(cls, value):
-        if isinstance(value, str):
-            value = _datetime_to_nt_time(datetime.strptime(value, "%Y-%m-%d %H:%M:%S"))
+        if isinstance(value, basestring):
+            if value.startswith("@GMT-"):
+                dt = GMT_to_datetime(value)
+            else:
+                dt = datetime.strptime(value, "%Y-%m-%d %H:%M:%S")
+            value = _datetime_to_nt_time(dt)
         elif isinstance(value, datetime):
             value = _datetime_to_nt_time(value)
         

--- a/pike/test/negotiate.py
+++ b/pike/test/negotiate.py
@@ -53,8 +53,8 @@ class CapTest(test.PikeTest):
         self.chan.logoff()
         self.chan.connection.close()
 
-        self.conn = model.Client().connect(self.server, self.port)
-        self.client = self.conn.client
+        self.client = self.default_client
+        self.conn = self.client.connect(self.server, self.port)
 
     def teardown(self):
         self.conn.close()
@@ -175,8 +175,8 @@ class CapMulticredit(CapTest):
 @test.RequireDialect(smb2.DIALECT_SMB3_1_1)
 class NegotiateContext(test.PikeTest):
     def negotiate(self, *args, **kwds):
-        self.conn = model.Client().connect(self.server, self.port)
-        self.client = self.conn.client
+        self.client = self.default_client
+        self.conn = self.client.connect(self.server, self.port)
         return self.conn.negotiate(*args, **kwds).negotiate_response
 
     def test_preauth_integrity_capabilities(self):

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ def run_setup(with_extensions):
         ext_modules.append(lw_krb_module)
         cmdclass = dict(cmdclass, build_ext=ve_build_ext)
     setup(name='Pike',
-          version='0.2.3',
+          version='0.2.4',
           description='Pure python SMB client',
           author='Brian Koropoff',
           author_email='Brian.Koropoff@emc.com',


### PR DESCRIPTION
* Add timewarp/enumerate snapshot support

Minor fixes:
* netbios frame `len` field can now be modified by the test
* negotiate.py uses the default client (for accounting purposes)

Will be merging 11/28, please send feedback by then.