### PR TITLE
Integrate Version 0.2.5

### DIFF
--- a/pike/crypto.py
+++ b/pike/crypto.py
@@ -52,18 +52,18 @@ class EncryptionCapabilities(core.Frame):
     context_type = smb2.SMB2_ENCRYPTION_CAPABILITIES
     def __init__(self):
         self.ciphers = []
-        self.cipher_count = None
+        self.ciphers_count = None
 
     def _encode(self, cur):
-        if self.cipher_count is None:
-            self.cipher_count = len(self.ciphers)
-        cur.encode_uint16le(self.cipher_count)
+        if self.ciphers_count is None:
+            self.ciphers_count = len(self.ciphers)
+        cur.encode_uint16le(self.ciphers_count)
         for c in self.ciphers:
             cur.encode_uint16le(c)
 
     def _decode(self, cur):
-        self.cipher_count = cur.decode_uint16le()
-        for ix in xrange(self.cipher_count):
+        self.ciphers_count = cur.decode_uint16le()
+        for ix in xrange(self.ciphers_count):
             self.ciphers.append(Ciphers(cur.decode_uint16le()))
 
 

--- a/pike/crypto.py
+++ b/pike/crypto.py
@@ -52,15 +52,18 @@ class EncryptionCapabilities(core.Frame):
     context_type = smb2.SMB2_ENCRYPTION_CAPABILITIES
     def __init__(self):
         self.ciphers = []
+        self.cipher_count = None
 
     def _encode(self, cur):
-        cur.encode_uint16le(len(self.ciphers))
+        if self.cipher_count is None:
+            self.cipher_count = len(self.ciphers)
+        cur.encode_uint16le(self.cipher_count)
         for c in self.ciphers:
             cur.encode_uint16le(c)
 
     def _decode(self, cur):
-        cipher_count = cur.decode_uint16le()
-        for ix in xrange(cipher_count):
+        self.cipher_count = cur.decode_uint16le()
+        for ix in xrange(self.cipher_count):
             self.ciphers.append(Ciphers(cur.decode_uint16le()))
 
 

--- a/pike/model.py
+++ b/pike/model.py
@@ -957,11 +957,14 @@ class Connection(transport.Transport):
                     context = self.conn._pre_auth_integrity_hash
                 for nctx in self.conn.negotiate_response:
                     if isinstance(nctx, crypto.EncryptionCapabilitiesResponse):
-                        return crypto.EncryptionContext(
-                            crypto.CryptoKeys311(
-                                self.session_key,
-                                context),
-                            nctx.ciphers)
+                        try:
+                            return crypto.EncryptionContext(
+                                crypto.CryptoKeys311(
+                                    self.session_key,
+                                    context),
+                                nctx.ciphers)
+                        except crypto.CipherMismatch:
+                            pass
             elif self.dialect_revision >= smb2.DIALECT_SMB3_0:
                 if self.conn.negotiate_response.capabilities & smb2.SMB2_GLOBAL_CAP_ENCRYPTION:
                     return crypto.EncryptionContext(

--- a/pike/smb2.py
+++ b/pike/smb2.py
@@ -762,14 +762,14 @@ class TreeConnectRequest(Request):
 
     def __init__(self, parent):
         Request.__init__(self, parent)
-        self.reserved = 0
+        self.flags = 0
         self.path_offset = None
         self.path_length = None
         self.path = None
 
     def _encode(self, cur):
-        # Reserved
-        cur.encode_uint16le(self.reserved)
+        # Reserved/Flags (SMB 3.1.1)
+        cur.encode_uint16le(self.flags)
         # Path Offset
         path_offset_hole = cur.hole.encode_uint16le(0)
         # Path Length

--- a/pike/smb2.py
+++ b/pike/smb2.py
@@ -479,7 +479,6 @@ class NegotiateRequest(Request):
         self.dialects = []
         self.negotiate_contexts_count = None
         self.negotiate_contexts_offset = None
-        self.negotiate_contexts_data_length = None
         self._negotiate_contexts = []
 
     def _children(self):
@@ -517,10 +516,9 @@ class NegotiateRequest(Request):
                 cur.encode_uint32le(0)      # reserved
                 data_start = cur.copy()
                 ctx.encode(cur)
-                if self.negotiate_contexts_data_length is not None:
-                    data_length_hole(self.negotiate_contexts_data_length)
-                else:
-                    data_length_hole(cur - data_start)
+                if ctx.data_length is None:
+                    ctx.data_length = cur - data_start
+                data_length_hole(ctx.data_length)
 
     def append(self, e):
         self._negotiate_contexts.append(e)
@@ -587,6 +585,7 @@ class NegotiateRequestContext(core.Frame):
         core.Frame.__init__(self, parent)
         if parent is not None:
             parent.append(self)
+        self.data_length = None
 
 @NegotiateResponse.negotiate_context
 class NegotiateResponseContext(core.Frame):

--- a/pike/smb2.py
+++ b/pike/smb2.py
@@ -599,19 +599,25 @@ class PreauthIntegrityCapabilities(core.Frame):
     context_type = SMB2_PREAUTH_INTEGRITY_CAPABILITIES
     def __init__(self):
         self.hash_algorithms = []
+        self.hash_algorithms_count = None
         self.salt = ""
+        self.salt_length = None
     def _encode(self, cur):
-        cur.encode_uint16le(len(self.hash_algorithms))
-        cur.encode_uint16le(len(self.salt))
+        if self.hash_algorithms_count is None:
+            self.hash_algorithms_count = len(self.hash_algorithms)
+        cur.encode_uint16le(self.hash_algorithms_count)
+        if self.salt_length is None:
+            self.salt_length = len(self.salt)
+        cur.encode_uint16le(self.salt_length)
         for h in self.hash_algorithms:
             cur.encode_uint16le(h)
         cur.encode_bytes(self.salt)
     def _decode(self, cur):
-        hash_algorithm_count = cur.decode_uint16le()
-        salt_length = cur.decode_uint16le()
-        for ix in xrange(hash_algorithm_count):
+        self.hash_algorithm_count = cur.decode_uint16le()
+        self.salt_length = cur.decode_uint16le()
+        for ix in xrange(self.hash_algorithm_count):
             self.hash_algorithms.append(HashAlgorithms(cur.decode_uint16le()))
-        self.salt = cur.decode_bytes(salt_length)
+        self.salt = cur.decode_bytes(self.salt_length)
 
 class PreauthIntegrityCapabilitiesRequest(NegotiateRequestContext,
                                           PreauthIntegrityCapabilities):

--- a/pike/smb2.py
+++ b/pike/smb2.py
@@ -479,6 +479,7 @@ class NegotiateRequest(Request):
         self.dialects = []
         self.negotiate_contexts_count = None
         self.negotiate_contexts_offset = None
+        self.negotiate_contexts_alignment_skew = 0
         self._negotiate_contexts = []
 
     def _children(self):
@@ -503,6 +504,7 @@ class NegotiateRequest(Request):
 
         if self._negotiate_contexts:
             cur.align(self.parent.start, 8)
+            cur.seekto(cur + self.negotiate_contexts_alignment_skew)
             if self.negotiate_contexts_offset is not None:
                 negotiate_contexts_offset_hole(
                         self.negotiate_contexts_offset)

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ def run_setup(with_extensions):
         ext_modules.append(lw_krb_module)
         cmdclass = dict(cmdclass, build_ext=ve_build_ext)
     setup(name='Pike',
-          version='0.2.4',
+          version='0.2.5',
           description='Pure python SMB client',
           author='Brian Koropoff',
           author_email='Brian.Koropoff@emc.com',


### PR DESCRIPTION
This version vastly improves transport-level error handling on linux.

Also generalize the query info system to allow querying info types which do not have structures and decoders predefined. Also allows for calling set info with an arbitrary buffer.

This change will be merged on or after 12/12. Please submit feedback by then.