### PR TITLE
Integrate 0.2.6

### DIFF
--- a/pike/MakeKitBuild
+++ b/pike/MakeKitBuild
@@ -1,5 +1,0 @@
-make()
-{
-    mk_stage DESTDIR="$PYTHON_DIST/pike" \
-        __init__.py core.py netbios.py smb2.py digest.py model.py nttime.py ntstatus.py test.py
-}

--- a/pike/__init__.py
+++ b/pike/__init__.py
@@ -1,1 +1,17 @@
-__all__ = ['core', 'netbios', 'smb2', 'digest', 'model', 'nttime', 'ntstatus', 'test', 'kerberos']
+__all__ = [
+        'auth',
+        'core',
+        'crypto',
+        'digest',
+        'kerberos',
+        'model',
+        'netbios',
+        'ntlm'
+        'nttime',
+        'ntstatus',
+        'smb2',
+        'test',
+        'transport',
+]
+__version_info__ = (0, 2, 6)
+__version__ = "{0}.{1}.{2}".format(*__version_info__)

--- a/pike/auth.py
+++ b/pike/auth.py
@@ -53,8 +53,11 @@ except ImportError:
 
 
 def split_credentials(creds):
-    nt4, password = creds.split('%')
-    domain, user = nt4.split('\\')
+    user, password = creds.split('%')
+    if '\\' in user:
+        domain, user = user.split('\\')
+    else:
+        domain = "NONE"
     return (domain, user, password)
 
 

--- a/pike/model.py
+++ b/pike/model.py
@@ -64,6 +64,7 @@ import transport
 import ntstatus
 import digest
 
+default_credit_request = 10
 default_timeout = 30
 trace = False
 
@@ -552,6 +553,10 @@ class Connection(transport.Transport):
                 data)
 
     def next_mid_range(self, length):
+        """
+        multicredit requests must reserve 1 message id per credit charged.
+        the message id of the request should be the first id of the range.
+        """
         if length < 1:
             length = 1
         start_range = self._next_mid
@@ -560,10 +565,8 @@ class Connection(transport.Transport):
             if not r.intersection(self._mid_blacklist):
                 break
             start_range += 1
-        result = sorted(list(r))[-1]
-        self._next_mid = result + 1
-
-        return result
+        self._next_mid = sorted(list(r))[-1] + 1
+        return start_range
 
     def next_mid(self):
         return self.next_range(1)
@@ -691,8 +694,8 @@ class Connection(transport.Transport):
                         req.credit_charge += 1
 
             if req.credit_request is None:
-                req.credit_request = 10
-                if req.credit_charge > 10:
+                req.credit_request = default_credit_request
+                if req.credit_charge > req.credit_request:
                     req.credit_request = req.credit_charge      # try not to fall behind
 
             if req.credit_charge > self.credits:

--- a/pike/model.py
+++ b/pike/model.py
@@ -282,6 +282,17 @@ class Client(object):
 
         self.logger = logging.getLogger('pike')
 
+    @contextlib.contextmanager
+    def callback(self, event, cb):
+        """
+        Register a callback function for the context block, then unregister it
+        """
+        self.register_callback(event, cb)
+        try:
+            yield
+        finally:
+            self.unregister_callback(event, cb)
+
     def register_callback(self, event, cb):
         """
         Registers a callback function, cb for the given event.
@@ -486,6 +497,17 @@ class Connection(transport.Transport):
             break
         self.create_socket(family, socktype)
         self.connect(sockaddr)
+
+    @contextlib.contextmanager
+    def callback(self, event, cb):
+        """
+        Register a callback function for the context block, then unregister it
+        """
+        self.register_callback(event, cb)
+        try:
+            yield
+        finally:
+            self.unregister_callback(event, cb)
 
     def register_callback(self, event, cb):
         """

--- a/pike/smb2.py
+++ b/pike/smb2.py
@@ -1858,9 +1858,9 @@ class QueryInfoResponse(Response):
         if context:
             request = context.get_request(parent.message_id)
 
-        if request and request.children and request[0].children:
-            self._info_type = request[0][0].info_type
-            self._file_information_class = request[0][0].file_information_class
+        if request and request.children:
+            self._info_type = request[0].info_type
+            self._file_information_class = request[0].file_information_class
 
         self._entries = []
 
@@ -2038,7 +2038,9 @@ class FileAllInformation(FileInformation):
 
     def _decode(self, cur):
         for field in self.fields:
-            getattr(self, field).decode(cur)
+            frame = getattr(self, field)
+            if isinstance(frame, core.Frame):
+                frame.decode(cur)
 
 class FileDirectoryInformation(FileInformation):
     file_information_class = FILE_DIRECTORY_INFORMATION

--- a/pike/test/__init__.py
+++ b/pike/test/__init__.py
@@ -127,7 +127,7 @@ class PikeTest(unittest.TestCase):
     def critical(self, *args, **kwargs):
         self.logger.critical(*args, **kwargs)
 
-    def tree_connect(self, client=None):
+    def tree_connect(self, client=None, resume=None):
         dialect_range = self.required_dialect()
         req_caps = self.required_capabilities()
         req_share_caps = self.required_share_capabilities()
@@ -145,7 +145,7 @@ class PikeTest(unittest.TestCase):
             self.skipTest("Capabilities missing: %s " %
                           str(req_caps & ~conn.negotiate_response.capabilities))
 
-        chan = conn.session_setup(self.creds)
+        chan = conn.session_setup(self.creds, resume=resume)
         if self.encryption:
             chan.session.encrypt_data = True
 

--- a/pike/test/ioctl.py
+++ b/pike/test/ioctl.py
@@ -40,6 +40,12 @@ import pike.smb2 as smb2
 import pike.test as test
 
 class ValidateNegotiateInfo(test.PikeTest):
+    def __init__(self, *args, **kwds):
+        super(ValidateNegotiateInfo, self).__init__(*args, **kwds)
+        self.default_client.dialects = [
+                smb2.DIALECT_SMB3_0,
+                smb2.DIALECT_SMB3_0_2]
+
     # VALIDATE_NEGOTIATE_INFO fsctl succeeds for SMB3
     @test.RequireDialect(smb2.DIALECT_SMB3_0, smb2.DIALECT_SMB3_0_2)
     def test_validate_negotiate_smb3(self):

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ from distutils.command.build_ext import build_ext
 from distutils.command.build_py import build_py
 from distutils.errors import CCompilerError, DistutilsExecError, \
                              DistutilsPlatformError
+from pike import __version__
 
 # attempt building the kerberos extension
 try_krb = True
@@ -75,7 +76,7 @@ def run_setup(with_extensions):
         ext_modules.append(lw_krb_module)
         cmdclass = dict(cmdclass, build_ext=ve_build_ext)
     setup(name='Pike',
-          version='0.2.5.1',
+          version=__version__,
           description='Pure python SMB client',
           author='Brian Koropoff',
           author_email='Brian.Koropoff@emc.com',


### PR DESCRIPTION
Fixes:
-------
  * calculate proper sequence number for multicredit requests (b78bc5b)
  * fix QueryInfoResponse file info class marshalling
  * ValidateNegotiateInfo test only applies to dialects 3.0.0 and 3.0.2

Enhancements:
---------
  * PIKE_CREDS can now be specified without a fake domain: "test_user%testpasswd" is now acceptable
  * Pike client/connection callback functionality can be used with a context manager
  * Pike version is now shipped with the package and can be queried from code