### PR TITLE
integrate 0.2.8

### DIFF
--- a/pike/__init__.py
+++ b/pike/__init__.py
@@ -13,5 +13,5 @@ __all__ = [
         'test',
         'transport',
 ]
-__version_info__ = (0, 2, 7)
+__version_info__ = (0, 2, 8)
 __version__ = "{0}.{1}.{2}".format(*__version_info__)

--- a/pike/model.py
+++ b/pike/model.py
@@ -1564,12 +1564,14 @@ class Channel(object):
         # frame
         self.connection.transceive(smb_req.parent)[0][0]
 
-    def flush(self, file):
+    def flush_request(self, file):
         smb_req = self.request(obj=file)
         flush_req = smb2.FlushRequest(smb_req)
         flush_req.file_id = file.file_id
+        return flush_req
 
-        self.connection.transceive(smb_req.parent)
+    def flush(self, file):
+        self.connection.transceive(self.flush_request(file).parent.parent)
 
     def read_request(
             self,

--- a/pike/smb2.py
+++ b/pike/smb2.py
@@ -702,8 +702,7 @@ class FlushResponse(Response):
         Response.__init__(self, parent)
 
     def _decode(self, cur):
-        # Reserved
-        cur.decode_uint16le()
+        self.reserved = cur.decode_uint16le()
 
 class SessionSetupRequest(Request):
     command_id = SMB2_SESSION_SETUP
@@ -1662,8 +1661,7 @@ class CloseResponse(Response):
 
     def _decode(self, cur):
         self.flags = CloseFlags(cur.decode_uint16le())
-        # Ignore Reserved
-        cur.decode_uint32le()
+        self.reserved = cur.decode_uint32le()
         self.creation_time = nttime.NtTime(cur.decode_uint64le())
         self.last_access_time = nttime.NtTime(cur.decode_uint64le())
         self.last_write_time = nttime.NtTime(cur.decode_uint64le())
@@ -3098,8 +3096,7 @@ class LockResponse(Response):
         Response.__init__(self, parent)
 
     def _decode(self, cur):
-        # Ignore reserved
-        cur.decode_uint16le()
+        self.reserved = cur.decode_uint16le()
 
 class IoctlCode(core.ValueEnum):
     FSCTL_DFS_GET_REFERRALS            = 0x00060194


### PR DESCRIPTION
Pulls in rodolfo's latest changes required for testing the encryption branch.

Save a few more reserved fields and separate flush helper function into 2 parts.