### PR TITLE
Fix ErrorResponse handling [0.2.16]

### DIFF
--- a/pike/__init__.py
+++ b/pike/__init__.py
@@ -13,5 +13,5 @@ __all__ = [
         'test',
         'transport',
 ]
-__version_info__ = (0, 2, 15)
+__version_info__ = (0, 2, 16)
 __version__ = "{0}.{1}.{2}".format(*__version_info__)

--- a/pike/model.py
+++ b/pike/model.py
@@ -570,6 +570,12 @@ class Connection(transport.Transport):
                 self._pre_auth_integrity_hash +
                 value.parent.parent.buf[4:])
 
+    @property
+    def dialect_revision(self):
+        return (self.negotiate_response.dialect_revision
+                if self.negotiate_response is not None
+                else 0x0)
+
     def next_mid_range(self, length):
         """
         multicredit requests must reserve 1 message id per credit charged.

--- a/pike/smb2.py
+++ b/pike/smb2.py
@@ -383,9 +383,6 @@ class ErrorResponse(Command):
             with cur.bounded(cur, end):
                 self.error_data = ctx(self, self.byte_count)
                 self.error_data.decode(cur)
-        else:
-           # Ignore ErrorData
-           cur += self.byte_count if self.byte_count else 1
 
 class ErrorId(core.ValueEnum):
     SMB2_ERROR_ID_DEFAULT = 0x0


### PR DESCRIPTION
* fixes issue where blindly decoding the "extra" byte as specified in [MS-SMB2] 2.2.2 results in BufferOverrun
* add property `dialect_revision` to `Connection` class
* add additional test cases to pike.test.compound