### PR TITLE
Concurrent Pike - wrappers for using threading

### DIFF
--- a/pike/__init__.py
+++ b/pike/__init__.py
@@ -13,5 +13,5 @@ __all__ = [
         'test',
         'transport',
 ]
-__version_info__ = (0, 2, 16)
+__version_info__ = (0, 3, 0)
 __version__ = "{0}.{1}.{2}".format(*__version_info__)

--- a/pike/concurrent.py
+++ b/pike/concurrent.py
@@ -63,7 +63,7 @@ class WorkThread(threading.Thread):
     def __init__(self, work_queue, killswitch, work_timeout, *args, **kwds):
         """
         constructor, remaining arguments are passed to threading.Thread
-        
+
         @type work_queue: L{Queue.Queue}
         @param work_queue: shared queue from the L{ThreadPool}
         @type killswitch: L{threading.Event}
@@ -133,7 +133,7 @@ class ThreadedFuture(model.Future):
         """
         super(ThreadedFuture, self).__init__(request)
         self.response_lock = threading.Lock()
-    
+
     def complete(self, response, traceback=None):
         with self.response_lock:
             self.response = response
@@ -176,7 +176,7 @@ class ThreadedClient(model.Client):
     def __del__(self):
         if self.cleanup_work_pool:
             self.work_pool.abort()
-    
+
     def connect_submit(self, server, port=445):
         return ThreadedConnection(self, server, port).establish().connection_future
 

--- a/pike/concurrent.py
+++ b/pike/concurrent.py
@@ -1,0 +1,286 @@
+#
+# Copyright (c) 2017, Dell Technologies
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# Module Name:
+#
+#       concurrent.py
+#
+# Abstract:
+#
+#       Improved concurrency in multi-connection environments
+#
+# Authors: Masen J. Furer (masen.furer@dell.com)
+#
+
+"""
+Connection concurrency hacks
+
+This module defines L{ThreadedClient} and L{ThreadedConnection}
+subclasses which provide additional locking and synchronization for use in a
+multithreaded environment.
+
+Specifically, encoding/decoding packets, sending/receiving data, and all
+callbacks and internal future completions will be scheduled for execution
+off of the main event loop.
+
+Care must be taken to ensure that callbacks and future completions (and subsequent
+notify functions) do not operate on unsynchronized data structures.
+"""
+
+import model
+import smb2
+
+import array
+import operator
+from Queue import Queue, Empty
+import struct
+import time
+import threading
+
+class WorkThread(threading.Thread):
+    def __init__(self, work_queue, killswitch, work_timeout, *args, **kwds):
+        """
+        constructor, remaining arguments are passed to threading.Thread
+        
+        @type work_queue: L{Queue.Queue}
+        @param work_queue: shared queue from the L{ThreadPool}
+        @type killswitch: L{threading.Event}
+        @param killswitch: signals to stop working
+        @type work_timeout: positive number
+        @param work_timeout: how long to wait on the queue
+        """
+        super(WorkThread, self).__init__(*args, **kwds)
+        self.work_queue = work_queue
+        self.killswitch = killswitch
+        self.work_timeout = work_timeout
+    def run(self):
+        """
+        Begin processing work from the queue
+        """
+        while not self.killswitch.is_set():
+            try:
+                func, future, lock = self.work_queue.get(timeout=self.work_timeout)
+                lock.acquire()
+                with future:
+                    try:
+                        future(func())
+                    finally:
+                        lock.release()
+            except Empty:
+                pass
+
+class ThreadPool(object):
+    def __init__(self, n_threads):
+        self.work_timeout = 1
+        self.killswitch = threading.Event()
+        self.work_queue = Queue()
+        self.work_threads = []
+        for x in xrange(n_threads):
+            t = WorkThread(self.work_queue, self.killswitch, self.work_timeout)
+            t.start()
+            self.work_threads.append(t)
+
+    def schedule(self, func, future, lock):
+        self.work_queue.put((func, future, lock))
+
+    def abort(self):
+        self.killswitch.set()
+        for t in self.work_threads:
+            t.join()
+
+class ThreadedFuture(model.Future):
+    """
+    Threaded future adds locking around the response member to allow
+    future completions to occur on arbitrary threads.
+
+    To execute code in the threaded context, use L{Future.then} to schedule
+    a completion routine.
+
+    To execute code in the event context, use L{Future.result} from top level
+    code. Never call L{Future.wait} from a callback or notify function
+
+    XXX: if the future is already complete, calling L{Future.then} from an event
+    context will run the completion routine on the event thread.
+    """
+
+    def __init__(self, request=None):
+        """
+        Initialize future.
+
+        @param request: The request associated with the response.
+        """
+        super(ThreadedFuture, self).__init__(request)
+        self.response_lock = threading.Lock()
+    
+    def complete(self, response, traceback=None):
+        with self.response_lock:
+            self.response = response
+            self.traceback = traceback
+
+        # run the callback functions outside of the lock
+        for notify in self.notify:
+            notify(self)
+
+    def interim(self, *args, **kwds):
+        with self.response_lock:
+            super(ThreadedFuture, self).interim(*args, **kwds)
+
+    def has_response(self):
+        with self.response_lock:
+            return self.response is not None
+
+    def has_interim_response(self):
+        with self.response_lock:
+            return self.response is not None or self.interim_response is not None
+
+class ThreadedClient(model.Client):
+
+    def __init__(self,
+                 dialects=[smb2.DIALECT_SMB2_002,
+                           smb2.DIALECT_SMB2_1,
+                           smb2.DIALECT_SMB3_0,
+                           smb2.DIALECT_SMB3_0_2,
+                           smb2.DIALECT_SMB3_1_1],
+                 capabilities=smb2.GlobalCaps(reduce(operator.or_, smb2.GlobalCaps.values())),
+                 security_mode=smb2.SMB2_NEGOTIATE_SIGNING_ENABLED,
+                 client_guid=None,
+                 work_pool=None):
+        super(ThreadedClient, self).__init__(dialects, capabilities, security_mode, client_guid)
+        self.cleanup_work_pool = False
+        if work_pool is None:
+            work_pool = ThreadPool(2)
+            self.cleanup_work_pool = True
+        self.work_pool = work_pool
+    def __del__(self):
+        if self.cleanup_work_pool:
+            self.work_pool.abort()
+    
+    def connect_submit(self, server, port=445):
+        """
+        Create a threaded connection.
+
+        Returns a new L{Future} object for the L{ThreadedConnection} being established
+        asynchronously to the given server and port.
+
+        @param server: The server to connect to.
+        @param port: The port to connect to.
+        """
+        return ThreadedConnection(self, server, port).establish().connection_future
+
+    ## TODO: oplock/lease break futures
+
+class ThreadedConnection(model.Connection):
+
+    def __init__(self, client, server, port=445):
+        """
+        Constructor.
+
+        This should generally not be used directly.  Instead,
+        use L{Client.connect}().
+        """
+        super(ThreadedConnection, self).__init__(client, server, port)
+        self.connection_future = ThreadedFuture()
+        self.work_pool = client.work_pool
+        self.socket_lock = threading.Lock()
+        self.work_futures = []
+
+    def submit(self, req):
+        """
+        When submitting on a ThreadedConnection, an additional future
+        will be returned for the completion of the work itself
+        catching any additional errors in packet marshalling, sending, or
+        user defined callbacks
+        """
+        self.raise_errors()
+        if self.error is not None:
+            raise self.error, None, self.traceback
+        futures = []
+        for smb_req in req:
+            if isinstance(smb_req[0], smb2.Cancel):
+                # Find original future being canceled to return
+                if smb_req.async_id is not None:
+                    # Cancel by async ID
+                    future = filter(lambda f: f.interim_response.async_id == smb_req.async_id, self._future_map.itervalues())[0]
+                elif smb_req.message_id in self._future_map:
+                    # Cancel by message id, already in future map
+                    future = self._future_map[smb_req.message_id]
+                else:
+                    # Cancel by message id, still in send queue
+                    future = filter(lambda f: f.request.message_id == smb_req.message_id, self._out_queue)[0]
+                # Add fake future for cancel since cancel has no response
+                self._out_queue.append(ThreadedFuture(smb_req))
+                futures.append(future)
+            else:
+                future = ThreadedFuture(smb_req)
+                self._out_queue.append(future)
+                futures.append(future)
+
+        # schedule the packet marshalling and sending to the work pool
+        write_future = ThreadedFuture()
+        self.work_futures.append(write_future)
+        self.work_pool.schedule(
+                self.handle_write,
+                write_future,
+                self.socket_lock)
+        return futures
+
+    def handle_read(self):
+        self.raise_errors()
+        # Try to read the next netbios frame
+        remaining = self._watermark - len(self._in_buffer)
+        self.process_callbacks(model.EV_RES_PRE_RECV, remaining)
+        data = array.array('B', self.recv(remaining))
+        self.process_callbacks(model.EV_RES_POST_RECV, data)
+        self._in_buffer.extend(data)
+        avail = len(self._in_buffer)
+        if avail >= 4:
+            self._watermark = 4 + struct.unpack('>L', self._in_buffer[0:4])[0]
+        if avail == self._watermark:
+            self.process_callbacks(model.EV_RES_PRE_DESERIALIZE, self._in_buffer)
+            nb_buf = self._in_buffer
+            self._in_buffer = array.array('B')
+            self._watermark = 4
+
+            # spin off the parsing and future completion to work pool
+            def do_parse():
+                nb = self.frame()
+                nb.parse(nb_buf)
+                self._dispatch_incoming(nb)
+            read_future = ThreadedFuture()
+            self.work_futures.append(read_future)
+            self.work_pool.schedule(
+                    do_parse,
+                    read_future,
+                    self.socket_lock)
+
+    def raise_errors(self):
+        """
+        sweep up errors returned from the work pool
+        """
+        for f in self.work_futures[:]:
+            if f.has_response():
+                f.result()
+                self.work_futures.remove(f)
+

--- a/pike/model.py
+++ b/pike/model.py
@@ -86,6 +86,11 @@ class StateError(Exception):
 class CreditError(Exception):
     pass
 
+class CallbackError(Exception):
+    """
+    the callback was not suitable
+    """
+
 class ResponseError(Exception):
     def __init__(self, response):
         Exception.__init__(self, response.command, response.status)
@@ -221,6 +226,8 @@ class Future(object):
                        when its result becomes available.  If it is already available,
                        it will be called immediately.
         """
+        if not callable(notify):
+            raise CallbackError("{0} is not a callable object".format(notify))
         if self.response is not None:
             notify(self)
         else:
@@ -1459,7 +1466,7 @@ class Channel(object):
 
     def close_submit(self, close_req):
         resp_future = self.connection.submit(close_req.parent.parent)[0]
-        resp_future.then(close_req.handle.dispose())
+        resp_future.then(lambda f: close_req.handle.dispose())
         return resp_future
 
     def close(self, handle):
@@ -1592,6 +1599,7 @@ class Channel(object):
         cnotify_req.file_id = handle.file_id
         cnotify_req.buffer_length = buffer_length
         cnotify_req.flags = flags
+        cnotify_req.completion_filter = completion_filter
         return cnotify_req
 
     def change_notify(

--- a/pike/test/concurrent.py
+++ b/pike/test/concurrent.py
@@ -1,0 +1,330 @@
+"""
+This test serves as an example for writing high-scale workflow tests utilizing
+thousands of connections and a fully asynchrounous chained-callback style using
+Future completion to chain events.
+
+The test leverages pike.concurrent hacks in order to spin off packet encoding/decoding
+and callbacks/future completion to work threads in order to keep the event thread
+clear for processing incoming data.
+
+There is still room for improvement, as this can really only generate 5-10mb of
+traffic as it is.
+
+Example usage::
+
+    python -m unittest -c pike.test.concurrent.TestConnectScale
+    python -m unittest -c pike.test.concurrent.TestBFLG
+
+ConnectScale - establish a given number of connections and keep them idle for
+    a given period of time
+BFLG - baby's first load generator. super simple example of how to slam as many
+    WRITE requests as possible as a server
+
+Pike is designed to be an extensible test framework -- there are many
+bottlenecks in the system that slow us down extensively in exchange for
+flexibility. Pike is not designed to be a stress or load generation tool.
+However, it is extensible enough, that one theoretically could optimize
+some of the data paths in handle_read/handle_write and in the Smb2 / Command
+encode/decode routines to trade flexibility for speed.
+"""
+
+import pike.concurrent
+import pike.model
+import pike.smb2 as smb2
+import pike.test
+import pike.transport
+
+import array
+import time
+import threading
+
+class ConnectScaleClient(object):
+    def __init__(self, server, creds, share, connect_time, keepalive_time, work_pool):
+        """
+        Establish the connection
+        """
+        # if killswitch gets set, abort processing and complete the future
+        self.killswitch = threading.Event()
+        # when all iterations have completed, this future will complete
+        # client_future is also used to bubble exceptions to the top level
+        self.client_future = pike.model.Future()
+        self.creds = creds
+        self.share = share
+        self.stop_time = time.time() + connect_time
+        self.keepalive_time = keepalive_time
+        self.keepalive_timer = None
+        self.connection = None
+
+        pike.concurrent.ThreadedClient(work_pool=work_pool).connect_submit(server).then(
+                self.step_1_on_connect_send_negotiate)
+
+    def result(self, *args, **kwds):
+        return self.client_future.result(*args, **kwds)
+
+    def send_echo_async(self):
+        """
+        Send an echo request and return a future for the response
+        """
+        smb_req = self.channel.request()
+        enum_req = smb2.EchoRequest(smb_req)
+        return self.connection.submit(smb_req.parent)[0]
+
+    def fire_echo_async(self):
+        """
+        Send an echo request and set the callback to step_5
+        """
+        echo_future = self.send_echo_async()
+        echo_future.then(self.step_5_send_echo_loop)
+        self.keepalive_timer = None
+
+    def _internal_abort(self):
+        self.client_future.complete(False)
+        if self.connection is not None:
+            self.connection.close()
+
+    def step_1_on_connect_send_negotiate(self, connect_future):
+        """
+        Send the negotiate request
+        """
+        if self.killswitch.is_set():
+            self._internal_abort()
+            return
+        with self.client_future:
+            self.connection = connect_future.result()
+            self.connection.negotiate_submit(self.connection.negotiate_request()).then(
+                    self.step_2_on_negotiate_send_session_setup)
+
+    def step_2_on_negotiate_send_session_setup(self, negotiate_future):
+        """
+        Send the session setup request(s)
+        """
+        if self.killswitch.is_set():
+            self._internal_abort()
+            return
+        with self.client_future:
+            self.connection.SessionSetupContext(
+                    self.connection,
+                    self.creds).submit().then(
+                            self.step_3_on_session_send_tree_connect)
+
+    def step_3_on_session_send_tree_connect(self, channel_future):
+        """
+        Send the tree connect
+        """
+        if self.killswitch.is_set():
+            self._internal_abort()
+            return
+        with self.client_future:
+            self.channel = channel_future.result()
+            self.channel.tree_connect_submit(self.channel.tree_connect_request(self.share)).then(
+                    self.step_4_finish_tree_connect)
+
+    def step_4_finish_tree_connect(self, tree_future):
+        """
+        Save a reference to the tree and send first keepalive
+        """
+        if self.killswitch.is_set():
+            self._internal_abort()
+            return
+        with self.client_future:
+            self.tree = tree_future.result()
+            self.fire_echo_async()
+
+    def step_5_send_echo_loop(self, echo_future):
+        """
+        If the timeout has not expired, schedule an echo to be sent
+        """
+        if self.killswitch.is_set():
+            self._internal_abort()
+            return
+        with self.client_future:
+            # call .result() in the unlikely event that echo failed
+            echo_future.result()
+            if time.time() + self.keepalive_time < self.stop_time:
+                # the only time we should re-enter this function is when
+                # the timer has expired AND the echo result is available
+                if self.keepalive_timer and self.keepalive_timer.is_alive():
+                    raise AssertionError("keepalive_timer is active when it shouldn't be")
+                self.keepalive_timer = threading.Timer(self.keepalive_time, self.fire_echo_async)
+                self.keepalive_timer.start()
+            else:
+                self.client_future.complete(True)
+
+
+class TestConnectScale(pike.test.PikeTest):
+    def setUp(self):
+        self.work_pool = pike.concurrent.ThreadPool(16)
+    def tearDown(self):
+        self.work_pool.abort()
+    def _gen_connection_scale(self, n_connections, connect_time, keepalive_time):
+        """
+        Establish multiple connections to the server, negotiate, session_setup,
+        tree_connect and then send echo commands until the timeout expires
+        """
+        clients = []
+        for ix in xrange(n_connections):
+            clients.append(ConnectScaleClient(self.server, self.creds, self.share, connect_time, keepalive_time, self.work_pool))
+
+        # poll the clients and raise errors
+        while clients:
+            for c in clients[:]:
+                try:
+                    self.assertTrue(c.result(timeout=1))
+                    clients.remove(c)
+                except pike.model.TimeoutError:
+                    pass    # result not yet available
+                except:
+                    print("Unexpected error, setting killswitch")
+                    # unexpected error is encountered, kill all clients and bail
+                    map(lambda c: c.killswitch.set(), clients[:])
+                    pike.transport.loop(timeout=5)
+                    raise
+    def _test_1_30_5_connection_scale(self):
+        self._gen_connection_scale(1, 30, 5)
+    def test_1000_30_5_connection_scale(self):
+        self._gen_connection_scale(1000, 30, 5)
+
+class BFLGClient(object):
+    buf = array.array("B", "\0\1\2\3\4\5\6\7"*8192)
+    def __init__(self, server, creds, share, load_time, io_file_name, io_block_size, work_pool):
+        """
+        Establish the connection
+        """
+        # if killswitch gets set, abort processing and complete the future
+        self.killswitch = threading.Event()
+        # when all iterations have completed, this future will complete
+        # client_future is also used to bubble exceptions to the top level
+        self.client_future = pike.model.Future()
+        self.creds = creds
+        self.share = share
+        self.io_file_name = io_file_name
+        self.io_block_size = io_block_size
+        self.stop_time = time.time() + load_time
+        self.connection = None
+
+        pike.concurrent.ThreadedClient(work_pool=work_pool).connect_submit(server).then(
+                self.step_1_on_connect_send_negotiate)
+
+    def result(self, *args, **kwds):
+        return self.client_future.result(*args, **kwds)
+
+    def fire_write_async(self):
+        """
+        Send an write request and set the callback to step_6
+        """
+        write_future = self.connection.submit(self.channel.write_request(self.fh, 0, self.buf[:self.io_block_size]).parent.parent)[0]
+        write_future.then(self.step_6_send_write_loop)
+
+    def _internal_abort(self):
+        self.client_future.complete(False)
+        if self.connection is not None:
+            self.connection.close()
+
+    def step_1_on_connect_send_negotiate(self, connect_future):
+        """
+        Send the negotiate request
+        """
+        if self.killswitch.is_set():
+            self._internal_abort()
+            return
+        with self.client_future:
+            self.connection = connect_future.result()
+            self.connection.negotiate_submit(self.connection.negotiate_request()).then(
+                    self.step_2_on_negotiate_send_session_setup)
+
+    def step_2_on_negotiate_send_session_setup(self, negotiate_future):
+        """
+        Send the session setup request(s)
+        """
+        if self.killswitch.is_set():
+            self._internal_abort()
+            return
+        with self.client_future:
+            self.connection.SessionSetupContext(
+                    self.connection,
+                    self.creds).submit().then(
+                            self.step_3_on_session_send_tree_connect)
+
+    def step_3_on_session_send_tree_connect(self, channel_future):
+        """
+        Send the tree connect
+        """
+        if self.killswitch.is_set():
+            self._internal_abort()
+            return
+        with self.client_future:
+            self.channel = channel_future.result()
+            self.channel.tree_connect_submit(self.channel.tree_connect_request(self.share)).then(
+                    self.step_4_on_tree_connect_send_create)
+
+    def step_4_on_tree_connect_send_create(self, tree_future):
+        """
+        Save a reference to the tree and send create request
+        """
+        if self.killswitch.is_set():
+            self._internal_abort()
+            return
+        with self.client_future:
+            self.tree = tree_future.result()
+            create_future = self.connection.submit(self.channel.create_request(self.tree, self.io_file_name, share=0x7).parent.parent)[0]
+            create_future.then(self.step_5_on_create_begin_write_loop)
+
+    def step_5_on_create_begin_write_loop(self, create_future):
+        """
+        Create an Open from the create response and start the write loop
+        """
+        if self.killswitch.is_set():
+            self._internal_abort()
+            return
+        with self.client_future:
+            create_resp = create_future.result()
+            self.fh = pike.model.Open(self.tree, create_resp)
+            self.fire_write_async()
+
+    def step_6_send_write_loop(self, write_future):
+        """
+        If the timeout has not expired, schedule a write to be sent
+        """
+        if self.killswitch.is_set():
+            self._internal_abort()
+            return
+        with self.client_future:
+            # call .result() in the unlikely event that write failed
+            write_future.result()
+            if time.time() < self.stop_time:
+                self.fire_write_async()
+            else:
+                self.client_future.complete(True)
+
+class TestBFLG(pike.test.PikeTest):
+    def setUp(self):
+        self.work_pool = pike.concurrent.ThreadPool(16)
+    def tearDown(self):
+        self.work_pool.abort()
+    def _gen_write_load(self, n_connections, load_time, io_block_size):
+        """
+        Establish multiple connections to the server, negotiate, session_setup,
+        tree_connect, create and then send write commands until the timeout expires
+        """
+        clients = []
+        for ix in xrange(n_connections):
+            clients.append(BFLGClient(self.server, self.creds, self.share, load_time, "target_file_{0}".format(ix), io_block_size, self.work_pool))
+
+        # poll the clients and raise errors
+        while clients:
+            for c in clients[:]:
+                try:
+                    self.assertTrue(c.result(timeout=1))
+                    clients.remove(c)
+                except pike.model.TimeoutError:
+                    pass    # result not yet available
+                except:
+                    print("Unexpected error, setting killswitch")
+                    # unexpected error is encountered, kill all clients and bail
+                    map(lambda c: c.killswitch.set(), clients[:])
+                    pike.transport.loop(timeout=5)
+                    raise
+    def _test_1_30_8192_write_load(self):
+        self._gen_write_load(1, 30, 8192)
+    def test_512_30_65536_write_load(self):
+        self._gen_write_load(512, 30, 65536)

--- a/pike/transport.py
+++ b/pike/transport.py
@@ -38,6 +38,7 @@ from errno import errorcode, EBADF, ECONNRESET, ENOTCONN, ESHUTDOWN, \
                   EAGAIN
 import select
 import socket
+import threading
 import time
 
 _reraised_exceptions = (KeyboardInterrupt, SystemExit)
@@ -226,6 +227,7 @@ class BasePoller(object):
         """
         self.connections = {}
         self.deferred_writers = set()
+        self.poll_lock = threading.Lock()
 
     def add_channel(self, transport):
         """
@@ -261,7 +263,8 @@ class BasePoller(object):
         while True:
             if count is not None and complete_iterations >= count:
                 break
-            self.poll()
+            with self.poll_lock:
+                self.poll()
             if timeout is not None and time.time() > start + timeout:
                 break
             complete_iterations += 1


### PR DESCRIPTION
The most significant changes are introduced in pike/concurrent.py which is where all of the new threaded wrappers live.

Only minor changes were made elsewhere
* improve the implementation of `pike.model.Future` to make subclassing easier
* add locking around calls to `pike.transport.poll()`

This should have no effect on the execution of existing tests.

Also a decent enough excuse to go to pike-0.3