### PR TITLE
Fix NTLMv1 authentication

### DIFF
--- a/pike/ntlm.py
+++ b/pike/ntlm.py
@@ -38,7 +38,7 @@ import array
 import random
 import struct
 from socket import gethostname
-import Cryptodome.Cipher.DES as DES
+import Cryptodome.Cipher.DES
 import Cryptodome.Cipher.ARC4 as RC4
 import Cryptodome.Hash.HMAC as HMAC
 import Cryptodome.Hash.MD4 as MD4
@@ -60,7 +60,8 @@ def des_key_64(K):
     return "".join(out_key)
 
 def DES(K, D):
-    d1 = DES.new(des_key_64(K))
+    d1 = Cryptodome.Cipher.DES.new(des_key_64(K),
+                                   Cryptodome.Cipher.DES.MODE_ECB)
     return d1.encrypt(D)
 
 def DESL(K, D):


### PR DESCRIPTION
PyCryptodome DES.new constructor requires explicit mode declaration.
This code was previously using PyCrypto, which defaulted to MODE_ECB, so
we use that here.

Additionally importing the name as DES resulted in the function defined
as DES overriding the import. That was broken here:
https://github.com/emc-isilon/pike/commit/7eec789779e7260b5f3921912f0c1afbe3203113#diff-eac4830f11f78da64d1e83582502fbc9