### PR TITLE
Minor fixes to new copychunk tests

### DIFF
--- a/pike/model.py
+++ b/pike/model.py
@@ -1749,7 +1749,7 @@ class Channel(object):
         else:
             copychunk_req = smb2.CopyChunkCopyRequest(ioctl_req)
 
-        ioctl_req.max_output_response = 16384
+        ioctl_req.max_output_response = 12
         ioctl_req.file_id = target_file.file_id
         ioctl_req.flags |= smb2.SMB2_0_IOCTL_IS_FSCTL
         copychunk_req.source_key = resume_key

--- a/pike/test/copychunk.py
+++ b/pike/test/copychunk.py
@@ -55,12 +55,6 @@ SIMPLE_5_CHUNKS = [(0, 0, 4000), (4000, 4000, 4000), (8000, 8000, 4000),
                    (12000, 12000, 4000), (16000, 16000, 4000)]
 SIMPLE_5_CHUNKS_LEN = 20000
 
-# Max values
-
-SERVER_SIDE_COPY_MAX_NUMBER_OF_CHUNKS = 16
-SERVER_SIDE_COPY_MAX_CHUNK_SIZE = 1048576
-SERVER_SIDE_COPY_MAX_DATA_SIZE = 16777216
-
 def _gen_test_buffer(length):
     pattern = "".join([ chr(x) for x in xrange(ord(' '), ord('~'))])
     buf = (pattern * (length / (len(pattern)) + 1))[:length]
@@ -80,6 +74,11 @@ def _gen_random_test_buffer(length):
 # Main test
 ###
 class TestServerSideCopy(pike.test.PikeTest):
+    # these values are valid for Windows -- other servers may need to adjust
+    bad_resume_key_error = pike.ntstatus.STATUS_OBJECT_NAME_NOT_FOUND
+    max_number_of_chunks = 256
+    max_chunk_size = 1048576
+    max_data_size = 16777216
 
     def setUp(self):
         self.chan, self.tree = self.tree_connect()
@@ -99,7 +98,7 @@ class TestServerSideCopy(pike.test.PikeTest):
                                disposition=pike.smb2.FILE_SUPERSEDE).result()
         # get the max size of write per request
         max_write_size = min(self.chan.connection.negotiate_response.max_write_size,
-                             SERVER_SIDE_COPY_MAX_CHUNK_SIZE)
+                             self.max_chunk_size)
         total_len = len(content)
         this_offset = 0
         writes = []
@@ -245,9 +244,9 @@ class TestServerSideCopy(pike.test.PikeTest):
         """
 
         if random_chunk_size:
-            chunk_sz = random.randrange(1, SERVER_SIDE_COPY_MAX_CHUNK_SIZE + 1)
+            chunk_sz = random.randrange(1, self.max_chunk_size + 1)
         else:
-            chunk_sz = SERVER_SIDE_COPY_MAX_CHUNK_SIZE
+            chunk_sz = self.max_chunk_size
         total_len = random.randrange(1, 16 * chunk_sz)
         if random_offset:
             dst_offset = random.randrange(1, 4294967295 - total_len)
@@ -746,7 +745,7 @@ class TestServerSideCopy(pike.test.PikeTest):
         other_key = chan_2.resume_key(fh_src_2)[0][0].resume_key
 
         self.generic_negative_resume_key_test_case(
-            other_key, exp_error=pike.ntstatus.STATUS_OBJECT_NAME_NOT_FOUND)
+            other_key, exp_error=self.bad_resume_key_error)
 
     def test_bogus_resume_key(self):
         """
@@ -757,7 +756,7 @@ class TestServerSideCopy(pike.test.PikeTest):
         import array
         bogus_key = array.array('B', [255] * 24)
         self.generic_negative_resume_key_test_case(
-            bogus_key, exp_error=pike.ntstatus.STATUS_OBJECT_NAME_NOT_FOUND)
+            bogus_key, exp_error=self.bad_resume_key_error)
 
     def basic_ssc_random_test_case(self,
                                    chunks,
@@ -1077,7 +1076,9 @@ class TestServerSideCopy(pike.test.PikeTest):
         """
         block = _gen_test_buffer(30000)
         chunks = [(0, 0, 100)] * 300
-        exp_res = [256, 1048576, 16777216]
+        exp_res = [self.max_number_of_chunks,
+                   self.max_chunk_size,
+                   self.max_data_size]
         self.generic_ssc_boundary_test_case(block, chunks,
                                             exp_error=pike.ntstatus.STATUS_INVALID_PARAMETER,
                                             ssc_res=exp_res)
@@ -1089,7 +1090,9 @@ class TestServerSideCopy(pike.test.PikeTest):
         """
         block = _gen_test_buffer(1048577)
         chunks = [(0, 0, 1048577)]
-        exp_res = [256, 1048576, 16777216]
+        exp_res = [self.max_number_of_chunks,
+                   self.max_chunk_size,
+                   self.max_data_size]
         self.generic_ssc_boundary_test_case(block, chunks,
                                             exp_error=pike.ntstatus.STATUS_INVALID_PARAMETER,
                                             ssc_res=exp_res)
@@ -1101,7 +1104,9 @@ class TestServerSideCopy(pike.test.PikeTest):
         """
         block = _gen_test_buffer(2097153)
         chunks = [(0, 0, 1048576), (1048576, 1048576, 1048577)]
-        exp_res = [256, 1048576, 16777216]
+        exp_res = [self.max_number_of_chunks,
+                   self.max_chunk_size,
+                   self.max_data_size]
         self.generic_ssc_boundary_test_case(block, chunks,
                                             exp_error=pike.ntstatus.STATUS_INVALID_PARAMETER,
                                             ssc_res=exp_res)
@@ -1112,7 +1117,9 @@ class TestServerSideCopy(pike.test.PikeTest):
         """
         block = _gen_test_buffer(1048577)
         chunks = [(0, 0, 4294967295)]
-        exp_res = [256, 1048576, 16777216]
+        exp_res = [self.max_number_of_chunks,
+                   self.max_chunk_size,
+                   self.max_data_size]
         self.generic_ssc_boundary_test_case(block, chunks,
                                             exp_error=pike.ntstatus.STATUS_INVALID_PARAMETER,
                                             ssc_res=exp_res)

--- a/pike/test/copychunk.py
+++ b/pike/test/copychunk.py
@@ -68,7 +68,7 @@ def _gen_random_test_buffer(length):
         if i % length == 0 and i != 0:
             buf += '-'
         buf += str(random_str_seq[random.randint(0, len(random_str_seq) - 1)])
-    return buf 
+    return buf
 
 ###
 # Main test
@@ -631,7 +631,7 @@ class TestServerSideCopy(pike.test.PikeTest):
         self.generic_ssc_negative_test_case(src_access=pike.smb2.FILE_WRITE_DATA | \
                                                        pike.smb2.DELETE,
                                             exp_error=pike.ntstatus.STATUS_ACCESS_DENIED)
-        
+
     def test_neg_dst_no_read(self):
         """
         Try to copychunk with no read access on the destination file
@@ -894,7 +894,7 @@ class TestServerSideCopy(pike.test.PikeTest):
                                        write_thru=False, num_iter=1):
         """
         server side copy in multiple sessions, multiple iterations
-        with filepair, chunks, blocks, write_through flag as input 
+        with filepair, chunks, blocks, write_through flag as input
         parameters
         """
         num_sess = len(filepair)
@@ -947,7 +947,7 @@ class TestServerSideCopy(pike.test.PikeTest):
 
     def test_multiple_ssc_same_source_file(self):
         """
-        multiple server side copy operation which shares the same 
+        multiple server side copy operation which shares the same
         source file
         """
         num_sess = 5
@@ -970,7 +970,7 @@ class TestServerSideCopy(pike.test.PikeTest):
 
     def test_multiple_ssc_same_dest_file(self):
         """
-        multiple server side copy operation which shares the same 
+        multiple server side copy operation which shares the same
         destination file but with different destination offset
         """
         num_sess = 5
@@ -1072,7 +1072,7 @@ class TestServerSideCopy(pike.test.PikeTest):
 
     def test_neg_cross_max_chunks(self):
         """
-        request contains 300 chunks 
+        request contains 300 chunks
         """
         block = _gen_test_buffer(30000)
         chunks = [(0, 0, 100)] * 300


### PR DESCRIPTION
fixes some interoperability issues with OneFS (also my editor automatically fixes trailing whitespace)

test results:

Windows 2016
```
root@337619c88bb4:/git/pike# PIKE_SERVER=mfsea-w16-01 PIKE_SHARE=ifs PIKE_CREDS=administrator%a python -m unittest -v pike.test.copychunk.TestServerSideCopy
test_bogus_resume_key (pike.test.copychunk.TestServerSideCopy) ... ok
test_copy_big_file (pike.test.copychunk.TestServerSideCopy) ... ok
test_copy_max_chunks (pike.test.copychunk.TestServerSideCopy) ... ok
test_copy_multiple_chunks (pike.test.copychunk.TestServerSideCopy) ... ok
test_copy_small_file (pike.test.copychunk.TestServerSideCopy) ... ok
test_copy_write_max_chunks (pike.test.copychunk.TestServerSideCopy) ... ok
test_copy_write_multiple_chunks (pike.test.copychunk.TestServerSideCopy) ... ok
test_copy_write_small_file (pike.test.copychunk.TestServerSideCopy) ... ok
test_multiple_resume_key (pike.test.copychunk.TestServerSideCopy) ... ok
test_multiple_ssc_file (pike.test.copychunk.TestServerSideCopy) ... ok
test_multiple_ssc_file_with_writethrough_flag (pike.test.copychunk.TestServerSideCopy) ... ok
test_multiple_ssc_same_dest_file (pike.test.copychunk.TestServerSideCopy) ... ok
test_multiple_ssc_same_source_file (pike.test.copychunk.TestServerSideCopy) ... ok
test_neg_cross_chunk_size (pike.test.copychunk.TestServerSideCopy) ... ok
test_neg_cross_chunk_size_allf (pike.test.copychunk.TestServerSideCopy) ... ok
test_neg_cross_max_chunks (pike.test.copychunk.TestServerSideCopy) ... ok                                                                               test_neg_cross_offset_basic (pike.test.copychunk.TestServerSideCopy) ... ok
test_neg_cross_offset_fifth_chunk (pike.test.copychunk.TestServerSideCopy) ... ok
test_neg_cross_offset_second_chunk (pike.test.copychunk.TestServerSideCopy) ... ok
test_neg_cross_second_chunk_size (pike.test.copychunk.TestServerSideCopy) ... ok                                                                        test_neg_dst_exc_brl (pike.test.copychunk.TestServerSideCopy) ... ok
test_neg_dst_is_a_dir (pike.test.copychunk.TestServerSideCopy) ... ok
test_neg_dst_no_read (pike.test.copychunk.TestServerSideCopy) ... ok
test_neg_dst_no_write (pike.test.copychunk.TestServerSideCopy) ... ok                                                                                   test_neg_src_exc_brl (pike.test.copychunk.TestServerSideCopy) ... ok
test_neg_src_no_read (pike.test.copychunk.TestServerSideCopy) ... ok
test_offset_copy_big_file (pike.test.copychunk.TestServerSideCopy) ... ok
test_offset_copy_multiple_chunks (pike.test.copychunk.TestServerSideCopy) ... ok
test_offset_copy_small_file (pike.test.copychunk.TestServerSideCopy) ... ok
test_other_resume_key (pike.test.copychunk.TestServerSideCopy) ... ok
test_overlap_15_chunks_4096_overlap (pike.test.copychunk.TestServerSideCopy) ... ok
test_overlap_16_chunks_1024_overlap (pike.test.copychunk.TestServerSideCopy) ... ok
test_overlap_multiple_chunks (pike.test.copychunk.TestServerSideCopy) ... ok
test_random_all (pike.test.copychunk.TestServerSideCopy) ... ok
test_random_chunk_size (pike.test.copychunk.TestServerSideCopy) ... ok
test_random_copy_length (pike.test.copychunk.TestServerSideCopy) ... ok
test_random_file_offset (pike.test.copychunk.TestServerSideCopy) ... ok
test_same_big_file (pike.test.copychunk.TestServerSideCopy) ... ok
test_same_multiple_chunks (pike.test.copychunk.TestServerSideCopy) ... ok
test_same_offset_big_file (pike.test.copychunk.TestServerSideCopy) ... ok
test_same_offset_multiple_chunks (pike.test.copychunk.TestServerSideCopy) ... ok
test_same_offset_small_file (pike.test.copychunk.TestServerSideCopy) ... ok
test_same_small_file (pike.test.copychunk.TestServerSideCopy) ... ok
test_ssc_in_compound_req (pike.test.copychunk.TestServerSideCopy) ... ok
test_ssc_in_multchannel (pike.test.copychunk.TestServerSideCopy) ... ok

----------------------------------------------------------------------
Ran 45 tests in 32.416s

OK
root@337619c88bb4:/git/pike# git log --oneline -1
2917249 (HEAD -> mf-copychunk-integ, origin/mf-copychunk-integ) fix whitespace
```

[B_PIPE_DEV_1781](http://logindex.west.isilon.com/qa/log/helix/mfurer/task_logs/4440)
```
╒══════════╤══════════════════════════════╤═══════════╤══════════╤══════════╤═══════════╤════════════╤═══════════╕
│ Result   │ Suite Name                   │   # Tests │   Passes │   Errors │   Skipped │   Failures │   Runtime │
╞══════════╪══════════════════════════════╪═══════════╪══════════╪══════════╪═══════════╪════════════╪═══════════╡
│ PASS     │ test_pike.TestServerSideCopy │        45 │       39 │        0 │         6 │          0 │   180.502 │
╘══════════╧══════════════════════════════╧═══════════╧══════════╧══════════╧═══════════╧════════════╧═══════════╛

Generating Report
--------------------------------------------------------------------------------
2019-01-03 00:03:19,680 TestEnvironment  INFO     Generated HTML report at http://logindex.west.isilon.com/qa/log/helix/mfurer/task_logs/4440
```