### PR TITLE
Pike code coverage

### DIFF
--- a/pike/test/compound.py
+++ b/pike/test/compound.py
@@ -184,7 +184,7 @@ class CompoundTest(pike.test.PikeTest):
              write_res,
              close_res) = chan.connection.transceive(nb_req)
 
-    def test_create_faied_and_query(self):
+    def test_create_failed_and_query(self):
         chan, tree = self.tree_connect()
         name = "create_query_failed"
         test_dir = chan.create(tree,

--- a/pike/test/compound.py
+++ b/pike/test/compound.py
@@ -199,9 +199,12 @@ class CompoundTest(pike.test.PikeTest):
         
         query_req = chan.query_directory_request(RelatedOpen(tree))
         adopt(nb_req, query_req.parent)
-        
 
+        (create_future, query_future) = chan.connection.submit(nb_req)
         with self.assert_error(pike.ntstatus.STATUS_OBJECT_NAME_COLLISION):
-            (create_res1, query_res) = chan.connection.transceive(nb_req)
+            create_future.result()
+        
+        with self.assert_error(pike.ntstatus.STATUS_OBJECT_NAME_COLLISION):
+            query_future.result()
 
         chan.close(test_dir)

--- a/pike/test/compound.py
+++ b/pike/test/compound.py
@@ -41,6 +41,7 @@ import pike.test
 import random
 import array
 
+
 def adopt(new_parent, obj):
     """
     obj is adopted by new_parent
@@ -50,14 +51,16 @@ def adopt(new_parent, obj):
     if isinstance(obj, pike.smb2.Smb2):
         obj.flags |= pike.smb2.SMB2_FLAGS_RELATED_OPERATIONS
 
+
 class RelatedOpen(pike.model.Tree):
     """
     Shim to insert the RELATED_FID into the request
     """
     def __init__(self, tree=None):
-       self.tree_id = tree.tree_id
-       self.file_id = pike.smb2.RELATED_FID
-       self.encrypt_data = tree.encrypt_data if tree is not None else False
+        self.tree_id = tree.tree_id
+        self.file_id = pike.smb2.RELATED_FID
+        self.encrypt_data = tree.encrypt_data if tree is not None else False
+
 
 class CompoundTest(pike.test.PikeTest):
 
@@ -180,14 +183,14 @@ class CompoundTest(pike.test.PikeTest):
             (create_res1,
              write_res,
              close_res) = chan.connection.transceive(nb_req)
-    
+
     def test_create_faied_and_query(self):
         chan, tree = self.tree_connect()
         name = "create_query_failed"
         test_dir = chan.create(tree,
-                            name,
-                            access=pike.smb2.GENERIC_READ,
-                            options=pike.smb2.FILE_DIRECTORY_FILE).result()
+                               name,
+                               access=pike.smb2.GENERIC_READ,
+                               options=pike.smb2.FILE_DIRECTORY_FILE).result()
 
         create_req = chan.create_request(
                 tree,
@@ -196,14 +199,14 @@ class CompoundTest(pike.test.PikeTest):
                 disposition=pike.smb2.FILE_CREATE,
                 options=pike.smb2.FILE_DIRECTORY_FILE)
         nb_req = create_req.parent.parent
-        
+
         query_req = chan.query_directory_request(RelatedOpen(tree))
         adopt(nb_req, query_req.parent)
 
         (create_future, query_future) = chan.connection.submit(nb_req)
         with self.assert_error(pike.ntstatus.STATUS_OBJECT_NAME_COLLISION):
             create_future.result()
-        
+
         with self.assert_error(pike.ntstatus.STATUS_OBJECT_NAME_COLLISION):
             query_future.result()
 

--- a/pike/test/querydirectory.py
+++ b/pike/test/querydirectory.py
@@ -39,13 +39,19 @@ import pike.smb2
 import pike.test
 import pike.ntstatus
 
+
 class QueryDirectoryTest(pike.test.PikeTest):
     # Enumerate directory at FILE_DIRECTORY_INFORMATION level.
     # Test for presence of . and .. entries
     def test_file_directory_info(self):
+
         chan, tree = self.tree_connect()
-        
-        root = chan.create(tree, '', access=pike.smb2.GENERIC_READ, options=pike.smb2.FILE_DIRECTORY_FILE, share=pike.smb2.FILE_SHARE_READ).result()
+        root = chan.create(tree,
+                           '',
+                           access=pike.smb2.GENERIC_READ,
+                           options=pike.smb2.FILE_DIRECTORY_FILE,
+                           share=pike.smb2.FILE_SHARE_READ).result()
+
         names = map(lambda info: info.file_name, chan.enum_directory(root))
 
         self.assertIn('.', names)
@@ -58,7 +64,7 @@ class QueryDirectoryTest(pike.test.PikeTest):
     def test_specific_name(self):
         chan, tree = self.tree_connect()
         name = 'hello.txt'
-        
+
         hello = chan.create(tree,
                             name,
                             access=pike.smb2.GENERIC_WRITE | pike.smb2.GENERIC_READ | pike.smb2.DELETE,
@@ -78,33 +84,43 @@ class QueryDirectoryTest(pike.test.PikeTest):
 
         chan.close(hello)
         chan.close(root)
-    
+
     def test_file_id_both_directory_information(self):
 
         chan, tree = self.tree_connect()
-        root = chan.create(tree, '', access=pike.smb2.GENERIC_READ, options=pike.smb2.FILE_DIRECTORY_FILE, share=pike.smb2.FILE_SHARE_READ).result()
+        root = chan.create(tree,
+                           '',
+                           access=pike.smb2.GENERIC_READ,
+                           options=pike.smb2.FILE_DIRECTORY_FILE,
+                           share=pike.smb2.FILE_SHARE_READ).result()
 
-        result = chan.query_directory(root,file_information_class=pike.smb2.FILE_ID_BOTH_DIR_INFORMATION)
+        result = chan.query_directory(root, file_information_class=pike.smb2.FILE_ID_BOTH_DIR_INFORMATION)
         names = map(lambda info: info.file_name, result)
         self.assertIn('.', names)
         self.assertIn('..', names)
 
-        file_ids = map(lambda info: info.file_id, result)
-        self.assertNotIn( 0, file_ids )
+        valid_file_ids = map(lambda info: info.file_id >= 0, result)
+        self.assertNotIn(False, valid_file_ids)
 
         chan.close(root)
-        
+
     def test_restart_scan(self):
 
         chan, tree = self.tree_connect()
-        root = chan.create(tree, '', access=pike.smb2.GENERIC_READ, options=pike.smb2.FILE_DIRECTORY_FILE, share=pike.smb2.FILE_SHARE_READ).result()
+        root = chan.create(tree,
+                           '',
+                           access=pike.smb2.GENERIC_READ,
+                           options=pike.smb2.FILE_DIRECTORY_FILE,
+                           share=pike.smb2.FILE_SHARE_READ).result()
 
         result = chan.query_directory(root)
         names = map(lambda info: info.file_name, result)
         self.assertIn('.', names)
-        
-        result = chan.query_directory(root,flags=pike.smb2.SL_RESTART_SCAN,file_name='README*',)
+
+        result = chan.query_directory(root,
+                                      flags=pike.smb2.SL_RESTART_SCAN,
+                                      file_name='*')
         names = map(lambda info: info.file_name, result)
         self.assertIn('.', names)
-        
+
         chan.close(root)

--- a/pike/test/querydirectory.py
+++ b/pike/test/querydirectory.py
@@ -86,9 +86,11 @@ class QueryDirectoryTest(pike.test.PikeTest):
 
         result = chan.query_directory(root,file_information_class=pike.smb2.FILE_ID_BOTH_DIR_INFORMATION)
         names = map(lambda info: info.file_name, result)
-
         self.assertIn('.', names)
         self.assertIn('..', names)
+
+        file_ids = map(lambda info: info.file_id, result)
+        self.assertNotIn( 0, file_ids )
 
         chan.close(root)
         

--- a/pike/test/querydirectory.py
+++ b/pike/test/querydirectory.py
@@ -78,3 +78,31 @@ class QueryDirectoryTest(pike.test.PikeTest):
 
         chan.close(hello)
         chan.close(root)
+    
+    def test_file_id_both_directory_information(self):
+
+        chan, tree = self.tree_connect()
+        root = chan.create(tree, '', access=pike.smb2.GENERIC_READ, options=pike.smb2.FILE_DIRECTORY_FILE, share=pike.smb2.FILE_SHARE_READ).result()
+
+        result = chan.query_directory(root,file_information_class=pike.smb2.FILE_ID_BOTH_DIR_INFORMATION)
+        names = map(lambda info: info.file_name, result)
+
+        self.assertIn('.', names)
+        self.assertIn('..', names)
+
+        chan.close(root)
+        
+    def test_restart_scan(self):
+
+        chan, tree = self.tree_connect()
+        root = chan.create(tree, '', access=pike.smb2.GENERIC_READ, options=pike.smb2.FILE_DIRECTORY_FILE, share=pike.smb2.FILE_SHARE_READ).result()
+
+        result = chan.query_directory(root)
+        names = map(lambda info: info.file_name, result)
+        self.assertIn('.', names)
+        
+        result = chan.query_directory(root,flags=pike.smb2.SL_RESTART_SCAN,file_name='README*',)
+        names = map(lambda info: info.file_name, result)
+        self.assertIn('.', names)
+        
+        chan.close(root)


### PR DESCRIPTION
C:\Python27\Lib\site-packages\pike\test>python -m unittest -v compound.CompoundTest
test_create_close (compound.CompoundTest) ...
ok
test_create_faied_and_query (compound.CompoundTest) ...
ok
test_create_query_close (compound.CompoundTest) ...
ok
test_create_write_close (compound.CompoundTest) ...
ok
test_create_write_close_access_denied (compound.CompoundTest) ...
ok

----------------------------------------------------------------------
Ran 5 tests in 8.856s

OK

C:\Python27\Lib\site-packages\pike\test>python -m unittest -v querydirectory.QueryDirectoryTest
test_file_directory_info (querydirectory.QueryDirectoryTest) ...
ok
test_file_id_both_directory_information (querydirectory.QueryDirectoryTest) ...
ok
test_restart_scan (querydirectory.QueryDirectoryTest) ...
ok
test_specific_name (querydirectory.QueryDirectoryTest) ...
ok

----------------------------------------------------------------------
Ran 4 tests in 10.042s