### PR TITLE
Raise RequestError when attempting to submit non-Netbios frames 

### DIFF
--- a/pike/__init__.py
+++ b/pike/__init__.py
@@ -13,5 +13,5 @@ __all__ = [
         'test',
         'transport',
 ]
-__version_info__ = (0, 2, 18)
+__version_info__ = (0, 2, 19)
 __version__ = "{0}.{1}.{2}".format(*__version_info__)

--- a/pike/model.py
+++ b/pike/model.py
@@ -86,6 +86,13 @@ class StateError(Exception):
 class CreditError(Exception):
     pass
 
+class RequestError(Exception):
+    def __init__(self, request, message=None):
+        if message is None:
+            message = "Could not send {0}".format(repr(request))
+        Exception.__init__(self, message)
+        self.request = request
+
 class ResponseError(Exception):
     def __init__(self, response):
         Exception.__init__(self, response.command, response.status)
@@ -821,6 +828,10 @@ class Connection(transport.Transport):
         a list of L{Future} objects, one for each corresponding
         L{smb2.Smb2} frame in the request.
         """
+        if not isinstance(req, netbios.Netbios):
+            raise RequestError(
+                    req,
+                    "{0} is not a netbios.Netbios frame".format(repr(req)))
         if self.error is not None:
             raise self.error, None, self.traceback
         futures = []


### PR DESCRIPTION
Previously, passing an object that isn't a `Netbios` frame to `submit` or `transceive` will cause the pike internal loop to hang -- additionally no `Future` is allocated so the 30-second default timeout does not apply.

This change allows pike to fail fast when an inappropriate object is supplied. This is mainly for the benefit of the programmer during test development.