### PR TITLE
Network Resiliency Request (Resilient Handles) tests

### DIFF
--- a/pike/model.py
+++ b/pike/model.py
@@ -1938,9 +1938,13 @@ class Open(object):
         if durable_res != []:
             self.is_durable = True
 
+
         if prev is not None:
+            self.is_durable = True
             self.durable_timeout = prev.durable_timeout
             self.durable_flags = prev.durable_flags
+
+
 
         if self.oplock_level != smb2.SMB2_OPLOCK_LEVEL_NONE:
             if self.oplock_level == smb2.SMB2_OPLOCK_LEVEL_LEASE:

--- a/pike/model.py
+++ b/pike/model.py
@@ -1733,6 +1733,24 @@ class Channel(object):
 
         return self.connection.transceive(smb_req.parent)[0]
 
+    def network_resiliency_request_request(self, file, timeout):
+        smb_req = self.request(obj=file.tree)
+        ioctl_req = smb2.IoctlRequest(smb_req)
+
+        vni_req = smb2.NetworkResiliencyRequestRequest(ioctl_req)
+        ioctl_req.file_id = file.file_id
+        ioctl_req.max_output_response = 4096
+        ioctl_req.flags = smb2.SMB2_0_IOCTL_IS_FSCTL
+        vni_req.timeout = timeout
+        vni_req.Reserved = 1
+        return ioctl_req
+
+    def network_resiliency_request(self, file, timeout):
+        return self.connection.transceive(
+
+            self.network_resiliency_request_request(file, timeout).parent.parent
+        )[0]
+
     def copychunk_request(self, source_file, target_file, chunks, resume_key=None, write_flag=False):
         """
         @param source_file: L{Open}

--- a/pike/smb2.py
+++ b/pike/smb2.py
@@ -3244,6 +3244,18 @@ class RequestResumeKeyRequest(IoctlInput):
     def  _encode(self, cur):
         pass
 
+class NetworkResiliencyRequestRequest(IoctlInput):
+    ioctl_ctl_code = FSCTL_LMR_REQUEST_RESILIENCY
+
+    def __init__(self, parent):
+        IoctlInput.__init__(self, parent)
+        self.timeout = 0
+        self.reserved = 0
+
+    def  _encode(self, cur):
+        cur.encode_uint32le(self.timeout)
+        cur.encode_uint32le(self.reserved)
+
 class CopyChunkCopyRequest(IoctlInput):
     ioctl_ctl_code = FSCTL_SRV_COPYCHUNK
 
@@ -3338,6 +3350,13 @@ class RequestResumeKeyResponse(IoctlOutput):
    def _decode(self, cur):
         self.resume_key = cur.decode_bytes(24)
         self.context_length = cur.decode_uint32le()
+
+class NetworkResiliencyRequestResponse(IoctlOutput):
+
+    ioctl_ctl_code = FSCTL_LMR_REQUEST_RESILIENCY
+
+    def _decode(self, cur):
+        pass
 
 class CopyChunkCopyResponse(IoctlOutput):
    ioctl_ctl_code = FSCTL_SRV_COPYCHUNK

--- a/pike/test/durable.py
+++ b/pike/test/durable.py
@@ -43,7 +43,7 @@ import array
 import time
 
 # for buffer too small
-class _testNetworkResiliencyRequestRequest(pike.smb2.NetworkResiliencyRequestRequest):
+class InvalidNetworkResiliencyRequestRequest(pike.smb2.NetworkResiliencyRequestRequest):
     def  _encode(self, cur):
         cur.encode_uint32le(self.timeout)
         cur.encode_uint16le(self.reserved)
@@ -78,6 +78,7 @@ class DurableHandleTest(pike.test.PikeTest):
         handle1 = self.create(chan, tree, durable=durable)
 
         self.assertEqual(handle1.lease.lease_state, self.rwh)
+        self.assertTrue(handle1.is_durable)
 
         chan.close(handle1)
 
@@ -87,6 +88,7 @@ class DurableHandleTest(pike.test.PikeTest):
         handle1 = self.create(chan, tree, durable=durable)
 
         self.assertEqual(handle1.lease.lease_state, self.rwh)
+        self.assertTrue(handle1.is_durable)
 
         # Close the connection
         chan.connection.close()
@@ -95,15 +97,15 @@ class DurableHandleTest(pike.test.PikeTest):
 
         # Request reconnect
         handle2 = self.create(chan2, tree2, durable=handle1)
-    
         self.assertEqual(handle2.lease.lease_state, self.rwh)
-
+        self.assertTrue(handle2.is_durable)
         chan2.close(handle2)
 
     def durable_reconnect_fails_client_guid_test(self, durable):
         chan, tree = self.tree_connect()
 
         handle1 = self.create(chan, tree, durable=durable)
+        self.assertTrue(handle1.is_durable)
 
         self.assertEqual(handle1.lease.lease_state, self.rwh)
 
@@ -120,14 +122,16 @@ class DurableHandleTest(pike.test.PikeTest):
         chan3, tree3 = self.tree_connect()
 
         handle3 = self.create(chan3, tree3, durable=handle1)
+        self.assertTrue(handle3.is_durable)
 
         chan3.close(handle3)
 
     def durable_invalidate_test(self, durable):
         chan, tree = self.tree_connect()
 
-        handle1 = self.create(chan, tree, durable=durable, lease=self.rw)
-        self.assertEqual(handle1.lease.lease_state, self.rw)
+        handle1 = self.create(chan, tree, durable=durable)
+        self.assertEqual(handle1.lease.lease_state, self.rwh)
+        self.assertTrue(handle1.is_durable)
 
         # Close the connection
         chan.connection.close()
@@ -153,13 +157,14 @@ class DurableHandleTest(pike.test.PikeTest):
             handle3 = self.create(chan3, tree3, durable=handle1)
 
     @pike.test.RequireDialect(pike.smb2.DIALECT_SMB2_1)
-    def test_resiliency_interact_durable(self, durable=True):
+    def test_resiliency_reconnect_before_timeout(self, durable=True):
         chan, tree = self.tree_connect()
-        handle1 = self.create(chan, tree, durable=durable, lease=self.rw)
+        handle1 = self.create(chan, tree, durable=durable)
+        self.assertTrue(handle1.is_durable)
         timeout = 100
 
         a = chan.network_resiliency_request(handle1, timeout=timeout)
-        self.assertEqual(handle1.lease.lease_state, self.rw)
+        self.assertEqual(handle1.lease.lease_state, self.rwh)
 
         # Close the connection
         chan.connection.close()
@@ -179,17 +184,19 @@ class DurableHandleTest(pike.test.PikeTest):
         chan2.connection.close()
         chan3, tree3 = self.tree_connect()
         handle3 = self.create(chan3, tree3, durable=handle1)
+        self.assertTrue(handle3.is_durable)
 
         # cause of the resiliency, handle1.fileid would be equals to handle3's.
         self.assertEqual(handle1.file_id, handle3.file_id)
 
     @pike.test.RequireDialect(pike.smb2.DIALECT_SMB2_1)
-    def test_resiliency_timeout_interact_durable(self,durable=True):
+    def test_resiliency_reconnect_after_timeout(self,durable=True):
         chan, tree = self.tree_connect()
-        handle1 = self.create(chan, tree, durable=durable, lease=self.rw)
+        handle1 = self.create(chan, tree, durable=durable, lease=self.rwh)
+        self.assertTrue(handle1.is_durable)
         timeout = 100
         a = chan.network_resiliency_request(handle1, timeout=timeout)
-        self.assertEqual(handle1.lease.lease_state, self.rw)
+        self.assertEqual(handle1.lease.lease_state, self.rwh)
 
         # Close the connection
         chan.connection.close()
@@ -216,26 +223,27 @@ class DurableHandleTest(pike.test.PikeTest):
 
     # test longth too small  windows:AssertionError: "STATUS_INVALID_PARAMETER"
     @pike.test.RequireDialect(pike.smb2.DIALECT_SMB2_1)
-    def test_buffer_too_small(self,durable=True):
+    def test_resiliency_buffer_too_small(self,durable=True):
         chan, tree = self.tree_connect()
         handle1 = self.create(chan,
                           tree,
-                          durable=durable,
-                          lease=self.rw)
+                          durable=durable)
+        self.assertTrue(handle1.is_durable)
 
         timeout = 5
         # with self.assert_error(pike.ntstatus.STATUS_BUFFER_TOO_SMALL):  just for onefs
         with self.assert_error(self.buffer_too_small_error): # for windows plat
             smb_req = chan.request(obj=handle1.tree)
             ioctl_req = pike.smb2.IoctlRequest(smb_req)
-            vni_req = _testNetworkResiliencyRequestRequest(ioctl_req)
+            # replace with invalid request that has short input buffer
+            invalid_nrr_req = InvalidNetworkResiliencyRequestRequest(ioctl_req)
             ioctl_req.file_id = handle1.file_id
             ioctl_req.flags = pike.smb2.SMB2_0_IOCTL_IS_FSCTL
-            vni_req.timeout = timeout
-            vni_req.reserved = 0
-            a = chan.connection.transceive(smb_req.parent)[0]
+            invalid_nrr_req.timeout = timeout
+            invalid_nrr_req.reserved = 0
+            a = chan.connection.transceive(ioctl_req.parent.parent)[0]
 
-        self.assertEqual(handle1.lease.lease_state, self.rw)
+        self.assertEqual(handle1.lease.lease_state, self.rwh)
         chan.connection.close()
 
         chan2, tree2 = self.tree_connect(client=pike.model.Client())
@@ -246,7 +254,7 @@ class DurableHandleTest(pike.test.PikeTest):
                           lease_key=self.lease2,
                           disposition=pike.smb2.FILE_OPEN)
 
-        self.assertEqual(handle2.lease.lease_state, self.rw)
+        self.assertEqual(handle2.lease.lease_state, self.rwh)
         chan2.close(handle2)
         chan2.connection.close()
 

--- a/pike/test/persistent.py
+++ b/pike/test/persistent.py
@@ -59,7 +59,6 @@ class _testNetworkResiliencyRequestRequest(pike.smb2.NetworkResiliencyRequestReq
 @test.RequireCapabilities(smb2.SMB2_GLOBAL_CAP_PERSISTENT_HANDLES)
 @test.RequireShareCapabilities(smb2.SMB2_SHARE_CAP_CONTINUOUS_AVAILABILITY)
 class Persistent(test.PikeTest):
-    buf_too_small_error = pike.ntstatus.STATUS_INVALID_PARAMETER
 
     def setup(self):
         self.lease_key = array.array('B',map(random.randint, [0]*16, [255]*16))
@@ -87,7 +86,6 @@ class Persistent(test.PikeTest):
     # Opening a persistent handle grants persistent flag
     def test_create(self):
         handle = self.create_persistent()
-
         self.channel.close(handle)
 
     # Reconnecting a persistent handle after TCP disconnect works and preserves lease
@@ -125,95 +123,145 @@ class Persistent(test.PikeTest):
         self.channel.connection.close()
         self.channel, self.tree = self.tree_connect()
         handle2 = self.create_persistent(prev_handle = handle1)
+        self.assertTrue(handle1)
+        self.assertTrue(handle2)
+        self.assertEqual(handle1.file_id, handle2.file_id)
         self.channel.close(handle2)
 
     def test_resiliency_interact_persistent(self):
-        chan, tree = self.tree_connect()
         handle1 = self.create_persistent()
-        print handle1
-        timeout = 100
-        # a = chan.network_resiliency_request(handle1, timeout=timeout)
-        print handle1.durable_flags
+        timeout = handle1.durable_timeout
+        a = self.channel.network_resiliency_request(handle1, timeout=timeout)
+        self.channel.connection.close()
+        print handle1.is_persistent
+        print handle1.is_durable
+
+        #  sleeping time < resiliemcy < ca's default 120s
+        time.sleep(15)
+        self.channel, self.tree = self.tree_connect(client=pike.model.Client())
+
+        # Invalidate handle from separate client
+        handle2 = self.channel.create(self.tree,
+                                      "persistent.txt",
+                                      access=smb2.FILE_READ_DATA,
+                                      share=SHARE_ALL,
+                                      disposition=pike.smb2.FILE_OPEN)
+
         self.channel.connection.close()
 
-        time.sleep((timeout - 10) / 1000)
+        self.channel, self.tree = self.tree_connect()
+        handle3 = self.create_persistent(prev_handle=handle1)
 
-        chan2, tree2 = self.tree_connect(client=pike.model.Client())
-        # Invalidate handle from separate client
-        with self.assert_error(ntstatus.STATUS_FILE_NOT_AVAILABLE):
-            handle2 = self.create(chan2,
-                                  tree2,
-                                  access=smb2.FILE_READ_DATA,
-                                  share=SHARE_ALL,
-                                  disposition=pike.smb2.FILE_OPEN)
-        chan2.connection.close()
+        # handle1 and handle3 has the same file_id, and the same persistent status
+        # it seams that resilience has not impacted the result of reconnect
+        self.assertTrue(handle1.is_persistent)
+        self.assertTrue(handle3.is_persistent)
+        self.assertEqual(handle1.file_id, handle3.file_id)
+        self.channel.close(handle3)
 
-        chan3, tree3 = self.tree_connect()
-        handle3 = self.create_persistent(chan3,tree3,prev_handle = handle1)
-        print handle3.durable_flags
-        self.assertEqual(handle2.lease.lease_state, LEASE_RWH)
-        chan3.connection.close()
+    def test_resiliency_timein_interact_durable(self):
+        handle1 = self.create_persistent()
+        timeout = 10000
+        a = self.channel.network_resiliency_request(handle1, timeout=timeout)
 
-    def test_resiliency_timeout_interact_durable(self):
-        chan, tree = self.tree_connect()
-        handle1 = self.create(chan, tree)
-        timeout = 100
-        a = chan.network_resiliency_request(handle1, timeout=timeout)
-        self.assertEqual(handle1.lease.lease_state, self.rw)
+        self.channel.connection.close()
 
-        # Close the connection
-        chan.connection.close()
-        time.sleep(timeout / 1000 + 5)  # timeout
+        #  sleeping time < resiliemcy < ca's default 120s
+        time.sleep(timeout / 1000.0 - 4.0)  # timeout
+        self.channel, self.tree = self.tree_connect()
+        handle3 = self.create_persistent(prev_handle=handle1)
 
-        chan2, tree2 = self.tree_connect(client=pike.model.Client())
-        # Invalidate handle from separate client
-        handle2 = self.create(chan2,
-                              tree2,
-                              access=smb2.FILE_READ_DATA,
-                              share=SHARE_ALL,
-                              disposition=pike.smb2.FILE_OPEN)
+        self.assertTrue(handle1.is_persistent)
+        self.assertTrue(handle3.is_persistent)
+        self.assertEqual(handle1.file_id, handle3.file_id)
+        self.channel.close(handle3)
 
-        self.assertEqual(handle2.lease.lease_state, self.rw)
-        chan2.close(handle2)
-        chan2.connection.close()
-        chan3, tree3 = self.tree_connect()
+    def test_timeout_resiliency_interact_durable(self):
+        handle1 = self.create_persistent()
+        timeout = 10000
+        # a = self.channel.network_resiliency_request(handle1, timeout=timeout)
+        # self.assertEqual(handle1.lease.lease_state, self.rw)
 
-        # Reconnect should fail(resiliency timeout)
+        self.channel.connection.close()
+
+        # resiliemcy < sleeping time < ca's default 120s
+        time.sleep(timeout / 1000.0 + 5.0)  # timeout
+        self.channel, self.tree = self.tree_connect()
+        handle3 = self.create_persistent(prev_handle=handle1)
+
+        # It seams that resilience timeout has not impacted the result
+        self.assertTrue(handle1.is_persistent)
+        self.assertTrue(handle3.is_persistent)
+        self.assertEqual(handle1.file_id, handle3.file_id)
+        self.channel.close(handle3)
+
+    def test_timeout_ca_resiliency_interact_persistent(self):
+        handle1 = self.create_persistent()
+
+        # set ca's timeout equals resiliency's timeout
+        timeout = handle1.durable_timeout
+        a = self.channel.network_resiliency_request(handle1, timeout=timeout)
+        self.channel.connection.close()
+
+        # resilience's timeout = ca's defaut 120s < sleeping time
+        time.sleep(121)
+
+        # timeout, can't get object name
+        self.channel, self.tree = self.tree_connect()
         with self.assert_error(pike.ntstatus.STATUS_OBJECT_NAME_NOT_FOUND):
-            handle3 = self.create(chan3, tree3, durable=handle1)
+            handle3 = self.create_persistent(prev_handle=handle1)
+
+    def test_timeout_cav2_interact_persistent(self):
+        handle1 = self.create_persistent()
+
+        # set ca's timeout equals resiliency's timeout
+        timeout = handle1.durable_timeout + 5000
+        a = self.channel.network_resiliency_request(handle1, timeout=timeout)
+        self.channel.connection.close()
+
+        # ca's defaut 120s < sleeping time < resilience's timeout
+        time.sleep(121)
+
+        self.channel, self.tree = self.tree_connect()
+
+        handle3 = self.create_persistent(prev_handle=handle1)
+
+        # sleeping time longer than ca's default, couldn't get object name, but shoter than resilience' time,so the result is true.
+        self.assertTrue(handle1.is_persistent)
+        self.assertTrue(handle3.is_persistent)
+        self.assertEqual(handle1.file_id, handle3.file_id)
+        self.channel.close(handle3)
 
     def test_buffer_too_small(self):
-        chan, tree = self.tree_connect()
-        handle1 = self.create(chan,
-                              tree)
+        handle1 = self.create_persistent()
 
         timeout = 5
-        # with self.assert_error(pike.ntstatus.STATUS_BUFFER_TOO_SMALL):  just for onefs
-        with self.assert_error(self.buf_too_small_error):  # for windows plat
-            smb_req = chan.request(obj=handle1.tree)
+        with self.assert_error(pike.ntstatus.STATUS_BUFFER_TOO_SMALL):  # just for onefs
+            smb_req = self.channel.request(obj=handle1.tree)
             ioctl_req = pike.smb2.IoctlRequest(smb_req)
             vni_req = _testNetworkResiliencyRequestRequest(ioctl_req)
             ioctl_req.file_id = handle1.file_id
             ioctl_req.flags = pike.smb2.SMB2_0_IOCTL_IS_FSCTL
             vni_req.Timeout = timeout
             vni_req.Reserved = 0
-            a = chan.connection.transceive(smb_req.parent)[0]
+            a = self.channel.connection.transceive(smb_req.parent)[0]
 
-        self.assertEqual(handle1.lease.lease_state, self.rw)
-        chan.connection.close()
+        # self.channel.connection.close()
 
-        chan2, tree2 = self.tree_connect(client=pike.model.Client())
-        handle2 = self.create(chan2,
-                              tree2,
-                              access=smb2.FILE_READ_DATA,
-                              share=SHARE_ALL,
-                              disposition=pike.smb2.FILE_OPEN)
+        self.channel, self.tree = self.tree_connect(client=pike.model.Client())
+        handle2 = self.channel.create(self.tree,
+                                      "persistent.txt",
+                                      access=smb2.FILE_READ_DATA,
+                                      share=SHARE_ALL,
+                                      disposition=pike.smb2.FILE_OPEN)
 
-        self.assertEqual(handle2.lease.lease_state, self.rw)
-        chan2.close(handle2)
-        chan2.connection.close()
+        self.channel.connection.close()
 
-        chan3, tree3 = self.tree_connect()
-        # buffer too small
-        with self.assert_error(pike.ntstatus.STATUS_OBJECT_NAME_NOT_FOUND):
-            handle3 = self.create(chan3, tree3, durable=handle1)
+        self.channel, self.tree = self.tree_connect()
+
+        # resiliency's buffer too small has not impacted persistent status
+        handle3 = self.create_persistent(prev_handle=handle1)
+        self.assertTrue(handle1.is_persistent)
+        self.assertTrue(handle3.is_persistent)
+        self.assertEqual(handle1.file_id, handle3.file_id)
+        self.channel.close(handle3)


### PR DESCRIPTION
@AnnieL01 I took your latest commits from yesterday and packaged them up like this. I think this is ready to merge, but please give it another once over and confirm that it meets your expectations.

PIKE_SERVER=mfsea-w16-01 PIKE_SHARE=ifs PIKE_CREDS=administrator%password python -m unittest -v pike.test.durable
test_durable (pike.test.durable.DurableHandleTest) ... ok
test_durable_invalidate (pike.test.durable.DurableHandleTest) ... ok
test_durable_reconnect (pike.test.durable.DurableHandleTest) ... ok
test_durable_reconnect_fails_client_guid (pike.test.durable.DurableHandleTest) ... ok
test_durable_reconnect_v2 (pike.test.durable.DurableHandleTest) ... ok
test_durable_reconnect_v2_fails_client_guid (pike.test.durable.DurableHandleTest) ... ok
test_durable_v2 (pike.test.durable.DurableHandleTest) ... ok
test_durable_v2_invalidate (pike.test.durable.DurableHandleTest) ... ok
test_resiliency_buffer_too_small (pike.test.durable.DurableHandleTest) ... ok
test_resiliency_reconnect_after_timeout (pike.test.durable.DurableHandleTest) ... ok
test_resiliency_reconnect_before_timeout (pike.test.durable.DurableHandleTest) ... ok
test_resiliency_upgrade_buffer_too_small (pike.test.durable.DurableHandleTest) ... ok
test_resiliency_upgrade_reconnect_after_timeout (pike.test.durable.DurableHandleTest) ... ok
test_resiliency_upgrade_reconnect_before_timeout (pike.test.durable.DurableHandleTest) ... ok

----------------------------------------------------------------------
Ran 14 tests in 11.205s

OK
PIKE_SERVER=mfpipe2-1 PIKE_SHARE=ca PIKE_CREDS=admin%password python -m unittest -v pike.test.persistent                             
test_buffer_too_small (pike.test.persistent.Persistent) ... ok
test_create (pike.test.persistent.Persistent) ... ok
test_open_while_disconnected (pike.test.persistent.Persistent) ... ok
test_reconnect (pike.test.persistent.Persistent) ... ok
test_resiliency_reconnect_after_timeout (pike.test.persistent.Persistent) ... ok
test_resiliency_reconnect_before_timeout (pike.test.persistent.Persistent) ... ok
test_resiliency_same_timeout_reconnect_after_timeout (pike.test.persistent.Persistent) ... ok
test_resiliency_same_timeout_reconnect_before_timeout (pike.test.persistent.Persistent) ... ok

----------------------------------------------------------------------
Ran 8 tests in 137.134s

OK