### PR TITLE
Add support for FSCTL_QUERY_NETWORK_INTERFACE_INFO at a basic level (…

### DIFF
--- a/pike/model.py
+++ b/pike/model.py
@@ -1734,7 +1734,7 @@ class Channel(object):
 
         return res
 
-    def query_network_interface_info(self, tree):
+    def query_network_interface_info_request(self, tree):
         smb_req = self.request(obj=tree)
         ioctl_req = smb2.IoctlRequest(smb_req)
         qni_req = smb2.QueryNetworkInterfaceInfoRequest(ioctl_req)
@@ -1744,9 +1744,12 @@ class Channel(object):
         ioctl_req.max_output_response = 65536
         ioctl_req.flags = smb2.SMB2_0_IOCTL_IS_FSCTL
 
-        res = self.connection.transceive(smb_req.parent)[0]
+        return ioctl_req
 
-        return res
+    def query_network_interface_info(self, tree):
+        return self.connection.transceive(
+            self.query_network_interface_info_request(
+                tree).parent.parent)[0]
 
     def resume_key(self, file):
         smb_req = self.request(obj=file.tree)

--- a/pike/model.py
+++ b/pike/model.py
@@ -1734,6 +1734,20 @@ class Channel(object):
 
         return res
 
+    def query_network_interface_info(self, tree):
+        smb_req = self.request(obj=tree)
+        ioctl_req = smb2.IoctlRequest(smb_req)
+        qni_req = smb2.QueryNetworkInterfaceInfoRequest(ioctl_req)
+        client = self.session.client
+
+        # Windows sends 65536 buffer
+        ioctl_req.max_output_response = 65536
+        ioctl_req.flags = smb2.SMB2_0_IOCTL_IS_FSCTL
+
+        res = self.connection.transceive(smb_req.parent)[0]
+
+        return res
+
     def resume_key(self, file):
         smb_req = self.request(obj=file.tree)
         ioctl_req = smb2.IoctlRequest(smb_req)

--- a/pike/smb2.py
+++ b/pike/smb2.py
@@ -3234,6 +3234,15 @@ class ValidateNegotiateInfoRequest(IoctlInput):
         for dialect in self.dialects:
             cur.encode_uint16le(dialect)
 
+class QueryNetworkInterfaceInfoRequest(IoctlInput):
+    ioctl_ctl_code = FSCTL_QUERY_NETWORK_INTERFACE_INFO
+
+    def __init__(self, parent):
+        IoctlInput.__init__(self, parent)
+
+    def  _encode(self, cur):
+        pass
+
 class RequestResumeKeyRequest(IoctlInput):
     ioctl_ctl_code = FSCTL_SRV_REQUEST_RESUME_KEY
 
@@ -3323,6 +3332,7 @@ class IoctlOutput(core.Frame):
         if parent is not None:
             parent.ioctl_output = self
 
+
 class ValidateNegotiateInfoResponse(IoctlOutput):
     ioctl_ctl_code = FSCTL_VALIDATE_NEGOTIATE_INFO
 
@@ -3338,6 +3348,15 @@ class ValidateNegotiateInfoResponse(IoctlOutput):
         self.client_guid = cur.decode_bytes(16)
         self.security_mode = SecurityMode(cur.decode_uint16le())
         self.dialect = Dialect(cur.decode_uint16le())
+
+class QueryNetworkInterfaceInfoResponse(IoctlOutput):
+    ioctl_ctl_code = FSCTL_QUERY_NETWORK_INTERFACE_INFO
+
+    def __init__(self, parent):
+        IoctlOutput.__init__(self, parent)
+
+    def _decode(self, cur):
+        pass
 
 class RequestResumeKeyResponse(IoctlOutput):
    ioctl_ctl_code = FSCTL_SRV_REQUEST_RESUME_KEY

--- a/pike/test/ioctl.py
+++ b/pike/test/ioctl.py
@@ -33,11 +33,13 @@
 #
 # Authors: Ki Anderson (kimberley.anderson@emc.com)
 #          Paul Martin (paul.o.martin@emc.com)
+#          Steve Leef (steven.leef@dell.com)
 #
 
 import pike.model as model
 import pike.smb2 as smb2
 import pike.test as test
+import pike.ntstatus
 
 class ValidateNegotiateInfo(test.PikeTest):
     def __init__(self, *args, **kwds):
@@ -51,3 +53,19 @@ class ValidateNegotiateInfo(test.PikeTest):
     def test_validate_negotiate_smb3(self):
         chan, tree = self.tree_connect()
         chan.validate_negotiate_info(tree)
+
+
+class QueryNetworkInterfaceInfo(test.PikeTest):
+    def __init__(self, *args, **kwds):
+        super(QueryNetworkInterfaceInfo, self).__init__(*args, **kwds)
+        self.default_client.dialects = [
+                smb2.DIALECT_SMB3_0,
+                smb2.DIALECT_SMB3_0_2]
+
+    @test.RequireDialect(smb2.DIALECT_SMB3_0, smb2.DIALECT_SMB3_0_2)
+    def test_query_interface_info_smb3(self):
+        chan, tree = self.tree_connect()
+        try:
+            chan.query_network_interface_info(tree)
+        except model.ResponseError as err:
+            self.assertEqual(err.response.status, pike.ntstatus.STATUS_SUCCESS)


### PR DESCRIPTION
…no encode/decode of request/response).

Add test to test/ioctl.py