### PR TITLE
[Helix 3] Fix minor bugs and longstanding annoyances

### DIFF
--- a/pike/__init__.py
+++ b/pike/__init__.py
@@ -13,5 +13,5 @@ __all__ = [
         'test',
         'transport',
 ]
-__version_info__ = (0, 2, 21)
+__version_info__ = (0, 2, 22)
 __version__ = "{0}.{1}.{2}".format(*__version_info__)

--- a/pike/test/lease.py
+++ b/pike/test/lease.py
@@ -43,15 +43,13 @@ import array
 @pike.test.RequireDialect(0x210)
 @pike.test.RequireCapabilities(pike.smb2.SMB2_GLOBAL_CAP_LEASING)
 class LeaseTest(pike.test.PikeTest):
-    def __init__(self, *args, **kwargs):
-        super(LeaseTest, self).__init__(*args, **kwargs)
-        self.share_all = pike.smb2.FILE_SHARE_READ | pike.smb2.FILE_SHARE_WRITE | pike.smb2.FILE_SHARE_DELETE
-        self.lease1 = array.array('B',map(random.randint, [0]*16, [255]*16))
-        self.lease2 = array.array('B',map(random.randint, [0]*16, [255]*16))
-        self.r = pike.smb2.SMB2_LEASE_READ_CACHING
-        self.rw = self.r | pike.smb2.SMB2_LEASE_WRITE_CACHING
-        self.rh = self.r | pike.smb2.SMB2_LEASE_HANDLE_CACHING
-        self.rwh = self.rw | self.rh
+    share_all = pike.smb2.FILE_SHARE_READ | pike.smb2.FILE_SHARE_WRITE | pike.smb2.FILE_SHARE_DELETE
+    lease1 = array.array('B',map(random.randint, [0]*16, [255]*16))
+    lease2 = array.array('B',map(random.randint, [0]*16, [255]*16))
+    r = pike.smb2.SMB2_LEASE_READ_CACHING
+    rw = r | pike.smb2.SMB2_LEASE_WRITE_CACHING
+    rh = r | pike.smb2.SMB2_LEASE_HANDLE_CACHING
+    rwh = rw | rh
 
     # Upgrade lease from RW to RWH, then break it to R
     def test_lease_upgrade_break(self):

--- a/pike/test/lease.py
+++ b/pike/test/lease.py
@@ -54,7 +54,7 @@ class LeaseTest(pike.test.PikeTest):
     # Upgrade lease from RW to RWH, then break it to R
     def test_lease_upgrade_break(self):
         chan, tree = self.tree_connect()
-        
+
         # Request rw lease
         handle1 = chan.create(tree,
                               'lease.txt',
@@ -62,9 +62,9 @@ class LeaseTest(pike.test.PikeTest):
                               oplock_level=pike.smb2.SMB2_OPLOCK_LEVEL_LEASE,
                               lease_key = self.lease1,
                               lease_state = self.rw).result()
-    
+
         self.assertEqual(handle1.lease.lease_state, self.rw)
-        
+
         handle2 = chan.create(tree,
                               'lease.txt',
                               share=self.share_all,
@@ -77,7 +77,7 @@ class LeaseTest(pike.test.PikeTest):
 
         # On break, voluntarily give up handle caching
         handle2.lease.on_break(lambda state: state & ~pike.smb2.SMB2_LEASE_HANDLE_CACHING)
-   
+
         # Break our lease
         handle3 = chan.create(tree,
                               'lease.txt',
@@ -105,7 +105,7 @@ class LeaseTest(pike.test.PikeTest):
                               oplock_level=pike.smb2.SMB2_OPLOCK_LEVEL_LEASE,
                               lease_key = self.lease1,
                               lease_state = self.rw).result()
-        
+
         # Upgrade to rwh
         handle2 = chan.create(tree,
                               'lease.txt',
@@ -113,7 +113,7 @@ class LeaseTest(pike.test.PikeTest):
                               oplock_level=pike.smb2.SMB2_OPLOCK_LEVEL_LEASE,
                               lease_key = self.lease1,
                               lease_state = self.rwh).result()
-        
+
         # Break our lease
         handle3_future = chan.create(tree,
                                      'lease.txt',
@@ -121,19 +121,19 @@ class LeaseTest(pike.test.PikeTest):
                                      oplock_level=pike.smb2.SMB2_OPLOCK_LEVEL_LEASE,
                                      lease_key = self.lease2,
                                      lease_state = self.rwh)
-        
+
         # Wait for break
         handle1.lease.future.wait()
-        
+
         # Close second handle
         chan.close(handle2)
-        
+
         # Now ack break
         handle1.lease.on_break(lambda state: state)
-        
+
         # Wait for handle3
         handle3 = handle3_future.result()
-        
+
         chan.close(handle1)
         chan.close(handle3)
 


### PR DESCRIPTION
* if callback is not callable raise `CallbackError`
* don't dispose the handle in `close_submit` (do it after the close returns!)
* pass `completion_filter` to struct in `change_notify_request`
* get rid of `__init__` function in pike/test/lease.py (needed for pytest compatability)