### PR TITLE
Make compound request helpers part of official API

### DIFF
--- a/pike/model.py
+++ b/pike/model.py
@@ -1997,8 +1997,6 @@ class Tree(object):
 
 class Open(object):
     def __init__(self, tree, smb_res, create_guid=None, prev=None):
-        object.__init__(self)
-
         self.create_response = smb_res[0]
 
         self.tree = tree
@@ -2113,6 +2111,16 @@ class Open(object):
             # If the underlying connection for the channel is closed explicitly
             # open will not able to find an appropriate channel, to send close.
             pass
+
+
+class RelatedOpen(object):
+    """
+    Use in place of a real `Open` object in compound requests to use a handle
+    from previous Create in the chain
+    """
+    def __init__(self, tree=None):
+        self.tree_id = tree.tree_id
+        self.file_id = smb2.RELATED_FID
 
 
 class Lease(object):

--- a/pike/netbios.py
+++ b/pike/netbios.py
@@ -78,3 +78,15 @@ class Netbios(core.Frame):
 
     def append(self, smb2_frame):
         self._smb2_frames.append(smb2_frame)
+
+    def adopt(self, child, related=True):
+        """
+        become the parent of child
+
+        :param related: if True and child is an Smb2 frame, set the flag
+                        SMB2_FLAGS_RELATED_OPERATIONS
+        """
+        self.append(child)
+        child.parent = self
+        if related and isinstance(child, smb2.Smb2):
+            child.flags |= smb2.SMB2_FLAGS_RELATED_OPERATIONS

--- a/pike/test/copychunk.py
+++ b/pike/test/copychunk.py
@@ -39,7 +39,6 @@ import pike.ntstatus
 import pike.smb2
 import pike.test
 import random
-import pike.test.compound as compound
 
 share_all = pike.smb2.FILE_SHARE_READ | \
             pike.smb2.FILE_SHARE_WRITE | \
@@ -833,13 +832,13 @@ class TestServerSideCopy(pike.test.PikeTest):
             fh_src, fh_dst, SIMPLE_5_CHUNKS)
         nb_req = ioctl_req.parent.parent
         read_req1 = self.chan.read_request(
-            compound.RelatedOpen(self.tree), SIMPLE_5_CHUNKS_LEN / 2, 0)
-        compound.adopt(nb_req, read_req1.parent)
-        read_req2 = self.chan.read_request(compound.RelatedOpen(
+            pike.model.RelatedOpen(self.tree), SIMPLE_5_CHUNKS_LEN / 2, 0)
+        nb_req.adopt(read_req1.parent)
+        read_req2 = self.chan.read_request(pike.model.RelatedOpen(
             self.tree), SIMPLE_5_CHUNKS_LEN / 2, SIMPLE_5_CHUNKS_LEN / 2)
-        compound.adopt(nb_req, read_req2.parent)
-        close_req = self.chan.close_request(compound.RelatedOpen(self.tree))
-        compound.adopt(nb_req, close_req.parent)
+        nb_req.adopt(read_req2.parent)
+        close_req = self.chan.close_request(pike.model.RelatedOpen(self.tree))
+        nb_req.adopt(close_req.parent)
 
         (ssc_res,
          read1_res,


### PR DESCRIPTION
`pike.netbios.Netbios.adopt` will re-parent a frame under the current netbios frame, making a chain of Smb2 requests

`pike.model.RelatedOpen` can be used where the API expects an `Open` to indicate that the operation should use a handle from a previous chained Create