### PR TITLE
Improve per-operation DEBUG logging

### DIFF
--- a/pike/core.py
+++ b/pike/core.py
@@ -386,6 +386,8 @@ class BadPacket(Exception):
 
 class Frame(object):
     field_blacklist = ['fields','parent','start','end']
+    LOG_CHILDREN_COUNT = False    # Include len(children) in __repr__
+    LOG_CHILDREN_EXPAND = False   # Include c._log_str for all children
 
     def __init__(self, parent, context=None):
         object.__setattr__(self, 'fields', [])
@@ -431,6 +433,41 @@ class Frame(object):
             valstr = child._str(indent + 1)
             res += "\n" + "  " * indent + valstr
         return res
+
+    def _log_str_expand_children(self):
+        """
+        return a list of _log_str output for all children
+        """
+        return [c._log_str() for c in self.children]
+
+    def _log_str_count_children(self):
+        """
+        return a list containing a string count of children wrapped in
+        parentheses
+        """
+        if self.children:
+            return ["({})".format(len(self.children))]
+        return []
+
+    def _log_str_children(self):
+        """
+        return a list of string components summarizing the children
+        """
+        components = []
+        if self.LOG_CHILDREN_COUNT:
+            components.extend(self._log_str_count_children())
+        if self.LOG_CHILDREN_EXPAND:
+            components.extend(self._log_str_expand_children())
+        return components
+
+    def _log_str(self):
+        """
+        Short description used for logging. Should provide basic context and be
+        under 100 characters
+        """
+        components = [type(self).__name__]
+        components.extend(self._log_str_children())
+        return " ".join(components)
 
     def _encode_pre(self, cur):
         self.start = cur.copy()

--- a/pike/crypto.py
+++ b/pike/crypto.py
@@ -114,6 +114,9 @@ class TransformHeader(core.Frame):
     If the encryption_context is not explicitly specified, then it will be looked
     up based on session_id from the parent Netbios frame's connection reference
     """
+    LOG_CHILDREN_COUNT = False
+    LOG_CHILDREN_EXPAND = True
+
     def __init__(self, parent):
         core.Frame.__init__(self, parent)
         self.protocol_id = array.array('B', "\xfdSMB")
@@ -133,6 +136,12 @@ class TransformHeader(core.Frame):
             parent.transform = self
         else:
             self._smb2_frames = []
+
+    def _log_str(self):
+        components = [type(self).__name__]
+        if self.children:
+            components.extend(self._log_str_children())
+        return " ".join(components)
 
     def _children(self):
         if self.parent is not None:

--- a/pike/model.py
+++ b/pike/model.py
@@ -755,7 +755,7 @@ class Connection(transport.Transport):
                     self.client.logger.debug('send (%s/%s -> %s/%s): %s',
                                              self.local_addr[0], self.local_addr[1],
                                              self.remote_addr[0], self.remote_addr[1],
-                                             ', '.join(f[0].__class__.__name__ for f in req.parent))
+                                             req.parent._log_str())
             else:
                 # Not ready to send chain
                 result = None
@@ -787,7 +787,7 @@ class Connection(transport.Transport):
             self.client.logger.debug('recv (%s/%s -> %s/%s): %s',
                                      self.remote_addr[0], self.remote_addr[1],
                                      self.local_addr[0], self.local_addr[1],
-                                     ', '.join(f[0].__class__.__name__ for f in res))
+                                     res._log_str())
         self.process_callbacks(EV_RES_POST_DESERIALIZE, res)
         for smb_res in res:
             # TODO: move credit tracking to callbacks

--- a/pike/netbios.py
+++ b/pike/netbios.py
@@ -39,12 +39,25 @@ import crypto
 import smb2
 
 class Netbios(core.Frame):
+    LOG_CHILDREN_COUNT = False
+    LOG_CHILDREN_EXPAND = True
+
     def __init__(self, context=None):
         core.Frame.__init__(self, None, context)
         self.len = None
         self.conn = context
         self.transform = None
         self._smb2_frames = []
+
+    def _log_str(self):
+        components = []
+        if self.transform:
+            return self.transform._log_str()
+        if not self.children:
+            components.append(type(self).__name__)
+        else:
+            components.append(", ".join(self._log_str_children()))
+        return " ".join(components)
 
     def _children(self):
         return self._smb2_frames


### PR DESCRIPTION
Create a `_log_str` interface in core.Frame which can be overridden to provide a string used for logging.

Define some `_log_str` overrides to provide context for common SMB2 operations such as Create, Read, Write, Query/Set Info, QueryDirectory, TreeConnect, and Negotiate

Before: https://gist.github.com/isi-mfurer/cb764230afea1289e7220b1906bd9025

After: https://gist.github.com/isi-mfurer/c1a07f3a88a7d538ebf10dd0c55b89e2