### PR TITLE
Use `pycryptodome` instead of `pycryptodomex`

### DIFF
--- a/pike/crypto.py
+++ b/pike/crypto.py
@@ -22,7 +22,10 @@ from builtins import object
 import array
 import random
 
-from Cryptodome.Cipher import AES
+try:
+    from Crypto.Cipher import AES
+except ImportError:
+    from Cryptodome.Cipher import AES
 
 from . import core
 from . import digest

--- a/pike/digest.py
+++ b/pike/digest.py
@@ -20,16 +20,28 @@ from builtins import range
 
 import array
 
-import Cryptodome.Hash.HMAC as HMAC
-import Cryptodome.Hash.SHA256 as SHA256
-import Cryptodome.Hash.SHA512 as SHA512
-import Cryptodome.Cipher.AES as AES
+try
+    import Crypto.Hash.HMAC as HMAC
+    import Crypto.Hash.SHA256 as SHA256
+    import Crypto.Hash.SHA512 as SHA512
+    import Crypto.Cipher.AES as AES
+except ImportError:
+    import Cryptodome.Hash.HMAC as HMAC
+    import Cryptodome.Hash.SHA256 as SHA256
+    import Cryptodome.Hash.SHA512 as SHA512
+    import Cryptodome.Cipher.AES as AES
 
 from . import core
 
 
-def sha256_hmac(key, message):
-    return array.array("B", HMAC.new(key.tobytes(), message.tobytes(), SHA256).digest())
+def sha256_hmac(key,message):
+    return array.array('B',
+        HMAC.new(
+            key.tobytes(),
+            message.tobytes(),
+            SHA256,
+        ).digest(),
+    )
 
 
 def aes128_cmac(key, message):

--- a/pike/digest.py
+++ b/pike/digest.py
@@ -20,7 +20,7 @@ from builtins import range
 
 import array
 
-try
+try:
     import Crypto.Hash.HMAC as HMAC
     import Crypto.Hash.SHA256 as SHA256
     import Crypto.Hash.SHA512 as SHA512

--- a/pike/ntlm.py
+++ b/pike/ntlm.py
@@ -23,11 +23,18 @@ import random
 from socket import gethostname
 import struct
 
-import Cryptodome.Cipher.DES
-import Cryptodome.Cipher.ARC4 as RC4
-import Cryptodome.Hash.HMAC as HMAC
-import Cryptodome.Hash.MD4 as MD4
-import Cryptodome.Hash.MD5 as MD5
+try:
+    import Crypto.Cipher.DES
+    import Crypto.Cipher.ARC4 as RC4
+    import Crypto.Hash.HMAC as HMAC
+    import Crypto.Hash.MD4 as MD4
+    import Crypto.Hash.MD5 as MD5
+except ImportError:
+    import Cryptodome.Cipher.DES
+    import Cryptodome.Cipher.ARC4 as RC4
+    import Cryptodome.Hash.HMAC as HMAC
+    import Cryptodome.Hash.MD4 as MD4
+    import Cryptodome.Hash.MD5 as MD5
 
 from . import core
 from . import nttime

--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,7 @@ def run_setup(with_extensions):
         install_requires=[
             'enum34~=1.1.6;  python_version ~= "2.7"',
             "attrs >= 19.3",
-            "pycryptodomex",
+            "pycryptodome",
             "future",
             "six",
         ],


### PR DESCRIPTION
While `pycryptodomex` and `pycryptodome` have similar lineages,
`pycryptodomex` doesn't seem to be as actively developed as
`pycryptodome` is.

Keep the `cryptodomex` namespace imports in place to allow existing
users to use `cryptodomex`, if it's already installed.

Signed-off-by: Enji Cooper <yaneurabeya@gmail.com>