### PR TITLE
remove unittest2

### DIFF
--- a/pike/__init__.py
+++ b/pike/__init__.py
@@ -13,5 +13,5 @@ __all__ = [
         'test',
         'transport',
 ]
-__version_info__ = (0, 2, 23)
+__version_info__ = (0, 2, 24)
 __version__ = "{0}.{1}.{2}".format(*__version_info__)

--- a/pike/test/__init__.py
+++ b/pike/test/__init__.py
@@ -38,13 +38,8 @@ import os
 import gc
 import logging
 import sys
+import unittest
 import contextlib
-
-# Try and import backported unittest2 module in python2.6
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
 
 import pike.model as model
 import pike.smb2 as smb2


### PR DESCRIPTION
this ends pike support for python 2.6