### PR TITLE
Generalize pike test infrastructure

### DIFF
--- a/pike/smb2.py
+++ b/pike/smb2.py
@@ -870,6 +870,10 @@ class ShareAccess(core.FlagEnum):
 
 ShareAccess.import_items(globals())
 
+FILE_SHARE_ALL = (
+    FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE
+)
+
 # Create dispositions
 class CreateDisposition(core.ValueEnum):
     FILE_SUPERSEDE    = 0x00000000
@@ -1219,6 +1223,11 @@ class LeaseState(core.FlagEnum):
     SMB2_LEASE_WRITE_CACHING  = 0x04
 
 LeaseState.import_items(globals())
+
+SMB2_LEASE_R = SMB2_LEASE_READ_CACHING
+SMB2_LEASE_RH = SMB2_LEASE_R | SMB2_LEASE_HANDLE_CACHING
+SMB2_LEASE_RW = SMB2_LEASE_R | SMB2_LEASE_WRITE_CACHING
+SMB2_LEASE_RWH = SMB2_LEASE_RH | SMB2_LEASE_RW
 
 class LeaseFlags(core.FlagEnum):
     SMB2_LEASE_FLAG_NONE              = 0x00

--- a/pike/test/__init__.py
+++ b/pike/test/__init__.py
@@ -388,7 +388,10 @@ class PikeTest(unittest.TestCase):
         self.port = Options.port()
         self.creds = Options.creds()
         self.share = Options.share()
+        self.signing = Options.signing()
         self.encryption = Options.encryption()
+        self.min_dialect = Options.min_dialect()
+        self.max_dialect = Options.max_dialect()
 
     def debug(self, *args, **kwargs):
         self.logger.debug(*args, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,12 @@ def run_setup(with_extensions):
         url="https://github.com/emc-isilon/pike",
         packages=["pike", "pike.test"],
         python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,<3.9",
-        install_requires=["pycryptodomex", "future"],
+        install_requires=[
+            'enum34~=1.1.6;  python_version ~= "2.7"',
+            'attrs~=19.3.0',
+            "pycryptodomex",
+            "future"
+        ],
         ext_modules=ext_modules,
         test_suite="setup.pike_suite",
         cmdclass=cmdclass,


### PR DESCRIPTION
# `pytest` friendly

While pike doesn't directly depend on `pytest`, these changes make pike easier to use outside the context of a unittest `TestCase` subclass.

## Enhanced `TreeConnect` API

Extract `TreeConnect` mechanism from `pike.test.PikeTest` (subclass of `unittest.TestCase`) into its own standalone class which can be used comfortably without unittest.

The new `TreeConnect` extends the old `PikeTest.tree_connect` function to allow more customization and better control over the process of establishing the connection, authenticating, and performing the tree connect. Each of these phases is exposed as a separate helper function to decouple the sequence of operations.

The `TreeConnect` instance can be used as a context manager to automatically clean up. Additionally, `close` and `__call__` methods are provided to allow for easily closing and re-establishing all related objects.

## Standalone `Options` enum

All pike environment variables are now defined in this new enum, which provides helper methods for extracting the values (with defaults). `TreeConnect` uses the `Options` class to populate unspecified fields. Since environment variables are dynamic and can be changed while a process is running, nothing is cached. This means that each new instance of TreeConnect or access to an Options accessor function will return the most current values.

# Quality of Life

* Added `FILE_SHARE_ALL` constant to `pike.smb2` finally
* Added lease state short names to `pike.smb2`
  * `SMB2_LEASE_R`
  * `SMB2_LEASE_RH`
  * `SMB2_LEASE_RW`
  * `SMB2_LEASE_RWH`

These "constants" are redefined as boilerplate in dozens of pike suites, so, it's time to stop doing that.