### PR TITLE
BufferOverrun will include full packet bytes

### DIFF
--- a/pike/core.py
+++ b/pike/core.py
@@ -44,7 +44,6 @@ from builtins import object
 import array
 from binascii import hexlify
 import struct
-import inspect
 
 from future.utils import with_metaclass
 

--- a/pike/core.py
+++ b/pike/core.py
@@ -42,14 +42,33 @@ from builtins import hex
 from builtins import str
 from builtins import object
 import array
+from binascii import hexlify
 import struct
 import inspect
 
 from future.utils import with_metaclass
 
+
 class BufferOverrun(Exception):
     """Buffer overrun exception"""
-    pass
+    def __init__(self, cursor, request, boundary):
+        self.cursor = cursor
+        self.request = request
+        self.boundary = boundary
+
+    @property
+    def message(self):
+        return "{} is {} bound {} in {!r}\nPacket buffer: {!r}".format(
+            self.request,
+            "below lower" if self.request < self.boundary else "above upper",
+            self.boundary,
+            self.cursor,
+            hexlify(self.cursor.array),
+        )
+
+    def __str__(self):
+        return self.message
+
 
 class Cursor(object):
     """
@@ -254,8 +273,10 @@ class Cursor(object):
         lower = self.bounds[0] if self.bounds[0] is not None else 0
         upper = self.bounds[1] if self.bounds[1] is not None else len(self.array)
 
-        if start < lower or end > upper:
-            raise BufferOverrun()
+        if start < lower:
+            raise BufferOverrun(self, start, lower)
+        if end > upper:
+            raise BufferOverrun(self, end, upper)
 
     def decode_bytes(self, size):
         self._check_bounds(self.offset, self.offset + size)
@@ -311,9 +332,10 @@ class Cursor(object):
 
     def seekto(self, o, lowerbound = None, upperbound = None):
         assert self.array is o.array
-        if (lowerbound is not None and o < lowerbound) or \
-           (upperbound is not None and o > upperbound):
-            raise BufferOverrun()
+        if lowerbound is not None and o < lowerbound:
+            raise BufferOverrun(self, o, lowerbound)
+        if upperbound is not None and o > upperbound:
+            raise BufferOverrun(self, o, upperbound)
         self.offset = o.offset
 
     def advanceto(self, o, bound = None):


### PR DESCRIPTION
`BufferOverrun` is inactionable unless it includes enough information to determine why the error occured.

Example output

```
  File "/Users/mfurer/code/isilon/pike/pike/core.py", line 534, in parse
    self.decode(cursor)
  File "/Users/mfurer/code/isilon/pike/pike/core.py", line 523, in decode
    self._decode(cur)
  File "/Users/mfurer/code/isilon/pike/pike/netbios.py", line 72, in _decode
    with cur.bounded(cur, end):
  File "/Users/mfurer/code/isilon/pike/pike/core.py", line 371, in bounded
    self._check_bounds(lower, upper)
  File "/Users/mfurer/code/isilon/pike/pike/core.py", line 279, in _check_bounds
    raise BufferOverrun(self, end, upper)
pike.core.BufferOverrun: 280 is above upper bound 278 in Cursor(<array.array object at 0x10ca37d70>,4,(None, None))
Packet buffer: b'00000114fe534d4240000000000000000000040001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000041000100110302008a8c2a17f5f24e5eb278dd8aaa90d42e1e0000000000010000001000000010006c52c4c7e53dd60166157c68c63dd60180005500d8000000605306062b0601050502a0493047a019301706092a864886f712010202060a2b06010401823702020aa32a3028a0261b246e6f745f646566696e65645f696e5f5246433431373840706c656173655f69676e6f72650000000100260000000000010020000100c93dfb463f3e99ed9030a66d28548c330a4ae9a65856237d00e61f68c14eb09f000002000400000000000100'
```
```