### PR TITLE
replace deprecated array.array.tostring usage with tobytes

### DIFF
--- a/.github/workflows/test_samba.yml
+++ b/.github/workflows/test_samba.yml
@@ -23,10 +23,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+    - uses: actions/setup-python@v2
+      if: "!endsWith(matrix.python-version, '-dev')"
       with:
         python-version: ${{ matrix.python-version }}
+    - uses: deadsnakes/action@v1.0.0
+      if: endsWith(matrix.python-version, '-dev')
+      with:
+        python-version: ${{ matrix.python-version }}
+    - run: python --version --version && which python
     - name: Install Pike
       run: python setup.py install
     - name: Install pytest

--- a/.github/workflows/test_samba.yml
+++ b/.github/workflows/test_samba.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [2.7, 3.6, 3.7, 3.8]
+        python-version: [2.7, 3.6, 3.7, 3.8, 3.9-dev, 3.10-dev]
 
     services:
       samba:

--- a/pike/__init__.py
+++ b/pike/__init__.py
@@ -1,3 +1,20 @@
+import six
+if six.PY2:
+    import array
+    oldarray = array.array
+    # monkey-patch tobytes for python 2.7
+    class newarray(oldarray):
+        def tobytes(self, *args, **kwargs):
+            return self.tostring(*args, **kwargs)
+
+        def __getslice__(self, *args, **kwargs):
+            return type(self)(self.typecode, super(newarray, self).__getslice__(*args, **kwargs))
+
+        def __add__(self, *args, **kwargs):
+            return type(self)(self.typecode, super(newarray, self).__add__(*args, **kwargs))
+
+    array.array = newarray
+
 __all__ = [
         'auth',
         'core',

--- a/pike/auth.py
+++ b/pike/auth.py
@@ -93,7 +93,7 @@ class KerberosProvider(object):
     def step(self, sec_buf):
         self.result = kerberos.authGSSClientStep(
                 self.context,
-                sec_buf.tostring())
+                sec_buf.tobytes())
         if self.result == 0:
             return (array.array(
                     'B',

--- a/pike/core.py
+++ b/pike/core.py
@@ -301,7 +301,7 @@ class Cursor(object):
         return self.decode_struct('<q')[0]
 
     def decode_utf16le(self, size):
-        return self.decode_bytes(size).tostring().decode('utf-16le')
+        return self.decode_bytes(size).tobytes().decode('utf-16le')
 
     def align(self, base, val):
         assert self.array is base.array

--- a/pike/crypto.py
+++ b/pike/crypto.py
@@ -259,18 +259,18 @@ class CryptoKeys300(object):
     """ Key generation for SMB 0x300 and 0x302 """
     def __init__(self, session_key, *args, **kwds):
         self.encryption = digest.derive_key(
-            session_key, b"SMB2AESCCM", b"ServerIn \0")[:16].tostring()
+            session_key, b"SMB2AESCCM", b"ServerIn \0")[:16].tobytes()
         self.decryption = digest.derive_key(
-            session_key, b"SMB2AESCCM", b"ServerOut\0")[:16].tostring()
+            session_key, b"SMB2AESCCM", b"ServerOut\0")[:16].tobytes()
 
 
 class CryptoKeys311(object):
     """ Key generation for SMB 0x311 + """
     def __init__(self, session_key, pre_auth_integrity_hash, *args, **kwds):
         self.encryption = digest.derive_key(
-            session_key, b"SMBC2SCipherKey", pre_auth_integrity_hash)[:16].tostring()
+            session_key, b"SMBC2SCipherKey", pre_auth_integrity_hash)[:16].tobytes()
         self.decryption = digest.derive_key(
-            session_key, b"SMBS2CCipherKey", pre_auth_integrity_hash)[:16].tostring()
+            session_key, b"SMBS2CCipherKey", pre_auth_integrity_hash)[:16].tobytes()
 
 
 class EncryptionContext(object):
@@ -293,18 +293,18 @@ class EncryptionContext(object):
     def encrypt(self, plaintext, authenticated_data, nonce):
         enc_cipher = AES.new(self.keys.encryption,
                              self.aes_mode,
-                             nonce=nonce[:self.nonce_length].tostring())
-        enc_cipher.update(authenticated_data.tostring())
-        ciphertext, signature = enc_cipher.encrypt_and_digest(plaintext.tostring())
+                             nonce=nonce[:self.nonce_length].tobytes())
+        enc_cipher.update(authenticated_data.tobytes())
+        ciphertext, signature = enc_cipher.encrypt_and_digest(plaintext.tobytes())
         return array.array('B', ciphertext), array.array('B', signature)
 
     def decrypt(self, ciphertext, signature, authenticated_data, nonce):
         dec_cipher = AES.new(self.keys.decryption,
                              self.aes_mode,
-                             nonce=nonce[:self.nonce_length].tostring())
-        dec_cipher.update(authenticated_data.tostring())
+                             nonce=nonce[:self.nonce_length].tobytes())
+        dec_cipher.update(authenticated_data.tobytes())
         return array.array(
                 'B',
                 dec_cipher.decrypt_and_verify(
-                    ciphertext.tostring(),
-                    signature.tostring()))
+                    ciphertext.tobytes(),
+                    signature.tobytes()))

--- a/pike/digest.py
+++ b/pike/digest.py
@@ -50,12 +50,12 @@ from . import core
 def sha256_hmac(key,message):
     return array.array('B',
         HMAC.new(
-            key.tostring(),
-            message.tostring(),
+            key.tobytes(),
+            message.tobytes(),
             SHA256).digest())
 
 def aes128_cmac(key,message):
-    aes = AES.new(key.tostring(), mode=AES.MODE_ECB)
+    aes = AES.new(key.tobytes(), mode=AES.MODE_ECB)
 
     def shiftleft(data):
         cin = 0
@@ -75,7 +75,7 @@ def aes128_cmac(key,message):
         zero = array.array('B', [0]*16)
         rb = array.array('B', [0]*15 + [0x87])
 
-        key1 = array.array('B', aes.encrypt(zero.tostring()))
+        key1 = array.array('B', aes.encrypt(zero.tobytes()))
 
         if shiftleft(key1):
             xor(key1, rb)
@@ -102,7 +102,7 @@ def aes128_cmac(key,message):
 
     for i in range(0, n - 1):
         xor(mac, message[i*16:i*16+16])
-        mac = array.array('B',aes.encrypt(mac.tostring()))
+        mac = array.array('B',aes.encrypt(mac.tobytes()))
 
     if last_complete:
         scratch[0:16] = message[-16:]
@@ -113,13 +113,13 @@ def aes128_cmac(key,message):
         xor(scratch, subkey2)
 
     xor(mac, scratch)
-    mac = array.array('B',aes.encrypt(mac.tostring()))
+    mac = array.array('B',aes.encrypt(mac.tobytes()))
 
     return mac
 
 def smb3_sha512(message):
     return array.array('B',
-            SHA512.new(message.tostring()).digest())
+            SHA512.new(message.tobytes()).digest())
 
 def derive_key(key, label, context):
     message = array.array('B')

--- a/pike/model.py
+++ b/pike/model.py
@@ -418,7 +418,7 @@ class Client(object):
                 break
 
         if future.response is None:
-            self._lease_break_map[lease_key.tostring()] = future
+            self._lease_break_map[lease_key.tobytes()] = future
 
         return future
 
@@ -452,7 +452,7 @@ class Client(object):
         @param lease_res: The lease create context response.
         """
 
-        lease_key = lease_res.lease_key.tostring()
+        lease_key = lease_res.lease_key.tobytes()
         if lease_key not in self._leases:
             lease = Lease(tree)
             self._leases[lease_key] = lease
@@ -465,7 +465,7 @@ class Client(object):
 
     # Internal function to remove lease from table
     def dispose_lease(self, lease):
-        del self._leases[lease.lease_key.tostring()]
+        del self._leases[lease.lease_key.tobytes()]
 
 class Connection(transport.Transport):
     """
@@ -781,7 +781,7 @@ class Connection(transport.Transport):
         return None
 
     def _find_lease_future(self, lease_key):
-        lease_key = lease_key.tostring()
+        lease_key = lease_key.tobytes()
         if lease_key in self.client._lease_break_map:
             return self.client._lease_break_map.pop(lease_key)
         return None

--- a/pike/netbios.py
+++ b/pike/netbios.py
@@ -72,7 +72,7 @@ class Netbios(core.Frame):
         with cur.bounded(cur, end):
             while (cur < end):
                 signature = cur.copy().decode_bytes(4)
-                if (signature.tostring() == b'\xfdSMB'):
+                if (signature.tobytes() == b'\xfdSMB'):
                     crypto.TransformHeader(self).decode(cur)
                 else:
                     smb2.Smb2(self).decode(cur)

--- a/pike/ntlm.py
+++ b/pike/ntlm.py
@@ -61,7 +61,7 @@ def des_key_64(K):
     out_key = array.array("B", K[0])
     for ix in range(1,len(in_key)):
         out_key.append(((ord(in_key[ix-1]) << (8-ix)) & 0xFF) | (ord(in_key[ix]) >> ix))
-    return out_key.tostring()
+    return out_key.tobytes()
 
 def DES(K, D):
     d1 = Cryptodome.Cipher.DES.new(des_key_64(K),
@@ -102,7 +102,7 @@ class Ntlm(core.Frame):
 
     def _decode(self, cur):
         signature = cur.decode_bytes(8)
-        if signature.tostring() != NTLM_SIGNATURE:
+        if signature.tobytes() != NTLM_SIGNATURE:
             raise core.BadPacket("Packet signature does not match")
         # determine the message type to pass off decoding
         message_type = cur.decode_uint32le()
@@ -575,7 +575,7 @@ def ComputeResponsev2(NegFlg, ResponseKeyNT, ResponseKeyLM, ServerChallenge,
     ntlmv2_client_challenge.challenge_from_client = ClientChallenge
     if av_pairs is not None:
         ntlmv2_client_challenge.av_pairs = av_pairs
-    temp = encode_frame(ntlmv2_client_challenge).tostring()
+    temp = encode_frame(ntlmv2_client_challenge).tobytes()
     NTProofStr = HMAC.new(ResponseKeyNT,
                           ServerChallenge + temp,
                           MD5).digest()
@@ -642,12 +642,12 @@ class NtlmAuthenticator(object):
          self.session_base_key) = ComputeResponsev1(self.auth_flags,
                                                     self.nt_hash,
                                                     self.lm_hash,
-                                                    self.server_challenge.tostring(),
-                                                    self.client_challenge.tostring())
+                                                    self.server_challenge.tobytes(),
+                                                    self.client_challenge.tobytes())
         self.key_exchange_key = KXKEY(self.auth_flags,
                                       self.session_base_key,
                                       self.lm_challenge_response,
-                                      self.server_challenge.tostring(),
+                                      self.server_challenge.tobytes(),
                                       self.lm_hash)
 
     def ntlmv2(self):
@@ -668,8 +668,8 @@ class NtlmAuthenticator(object):
          self.session_base_key) = ComputeResponsev2(self.auth_flags,
                                                     self.nt_hash,
                                                     self.nt_hash,
-                                                    self.server_challenge.tostring(),
-                                                    self.client_challenge.tostring(),
+                                                    self.server_challenge.tobytes(),
+                                                    self.client_challenge.tobytes(),
                                                     time,
                                                     server_name,
                                                     ctarget_info)
@@ -682,7 +682,7 @@ class NtlmAuthenticator(object):
         if self.auth_flags & NTLMSSP_NEGOTIATE_KEY_EXCH:
             r = RC4.new(self.key_exchange_key)
             self.exported_session_key = nonce(16)
-            return r.encrypt(self.exported_session_key.tostring())
+            return r.encrypt(self.exported_session_key.tobytes())
         else:
             self.exported_session_key = self.key_exchange_key
 

--- a/pike/smb2.py
+++ b/pike/smb2.py
@@ -224,7 +224,7 @@ class Smb2(core.Frame):
         signature_hole(self.signature)
 
     def _decode(self, cur):
-        if (cur.decode_bytes(4).tostring() != b'\xfeSMB'):
+        if (cur.decode_bytes(4).tobytes() != b'\xfeSMB'):
             raise core.BadPacket()
         if (cur.decode_uint16le() != 64):
             raise core.BadPacket()
@@ -1131,7 +1131,7 @@ class CreateResponse(Response):
                     data_offset = cur.decode_uint16le()
                     data_length = cur.decode_uint32le()
 
-                    name = (con_start + name_offset).decode_bytes(name_length).tostring()
+                    name = (con_start + name_offset).decode_bytes(name_length).tobytes()
 
                     cur.seekto(con_start + data_offset)
                     with cur.bounded(cur, cur + data_length):

--- a/pike/test/compound.py
+++ b/pike/test/compound.py
@@ -139,7 +139,7 @@ class CompoundTest(pike.test.PikeTest):
          read_res,
          close_res) = chan.connection.transceive(nb_req)
 
-        self.assertEqual(buf, read_res[0].data.tostring())
+        self.assertEqual(buf, read_res[0].data.tobytes())
 
     # Compound create/write/close with insufficient access
     def test_create_write_close_access_denied(self):

--- a/pike/test/copychunk.py
+++ b/pike/test/copychunk.py
@@ -207,7 +207,7 @@ class TestServerSideCopy(pike.test.PikeTest):
         read_list = []
         for the_offset, the_length in reads:
             read_list.append(self.chan.read(
-                file_handle, the_length, the_offset + add_offset).tostring())
+                file_handle, the_length, the_offset + add_offset).tobytes())
         return b"".join(read_list)
 
     def _gen_16mega_file(self, filename):
@@ -364,11 +364,11 @@ class TestServerSideCopy(pike.test.PikeTest):
         self.assertEqual(result[0][0].total_bytes_written, total_len)
 
         # read each file and verify the result
-        src_buf = self.chan.read(fh_src, total_len, 0).tostring()
+        src_buf = self.chan.read(fh_src, total_len, 0).tobytes()
         self.assertBufferEqual(src_buf, block)
         fh_dst_read = self._get_readable_handler(dst_filename)
         dst_buf = self.chan.read(
-            fh_dst_read, total_len, total_offset).tostring()
+            fh_dst_read, total_len, total_offset).tobytes()
         self.assertBufferEqual(dst_buf, block)
 
         self.chan.close(fh_dst_read)
@@ -458,12 +458,12 @@ class TestServerSideCopy(pike.test.PikeTest):
         self.assertEqual(result[0][0].total_bytes_written, total_len)
 
         # read the file and verify the result
-        src_buf = self.chan.read(fh_src, total_len, 0).tostring()
+        src_buf = self.chan.read(fh_src, total_len, 0).tobytes()
         self.assertBufferEqual(src_buf, block)
         if total_offset > 0:
-            offs_buf = self.chan.read(fh_src, total_offset, total_len).tostring()
+            offs_buf = self.chan.read(fh_src, total_offset, total_len).tobytes()
             self.assertBufferEqual(offs_buf, b"\x00" * total_offset)
-        dst_buf = self.chan.read(fh_src, total_len, total_len+total_offset).tostring()
+        dst_buf = self.chan.read(fh_src, total_len, total_len+total_offset).tobytes()
         self.assertBufferEqual(dst_buf, block)
 
         self.chan.close(fh_src)
@@ -531,7 +531,7 @@ class TestServerSideCopy(pike.test.PikeTest):
                 src_block[offset:offset+length]
             this_offset += chunk_sz
         dst_len = dst_offset + length
-        dst_block = dst_block[:dst_len].tostring()
+        dst_block = dst_block[:dst_len].tobytes()
 
         fh_src, fh_dst = self._open_src_dst(src_filename, dst_filename)
 
@@ -540,9 +540,9 @@ class TestServerSideCopy(pike.test.PikeTest):
         self.assertEqual(result[0][0].total_bytes_written, total_len)
 
         # read each file and verify the result
-        src_buf = self.chan.read(fh_src, total_len, 0).tostring()
+        src_buf = self.chan.read(fh_src, total_len, 0).tobytes()
         self.assertBufferEqual(src_buf, block)
-        dst_buf = self.chan.read(fh_dst, dst_len, 0).tostring()
+        dst_buf = self.chan.read(fh_dst, dst_len, 0).tobytes()
         self.assertBufferEqual(dst_buf, dst_block)
 
         self.chan.close(fh_src)
@@ -857,7 +857,7 @@ class TestServerSideCopy(pike.test.PikeTest):
         self.assertEqual(ssc_res[0][0].chunks_written, len(SIMPLE_5_CHUNKS))
         self.assertEqual(
             ssc_res[0][0].total_bytes_written, SIMPLE_5_CHUNKS_LEN)
-        dst_buf = read1_res[0].data.tostring() + read2_res[0].data.tostring()
+        dst_buf = read1_res[0].data.tobytes() + read2_res[0].data.tobytes()
         self.assertBufferEqual(dst_buf, block)
         self.chan.close(fh_src)
 
@@ -885,9 +885,9 @@ class TestServerSideCopy(pike.test.PikeTest):
         self.assertEqual(result[0][0].total_bytes_written, SIMPLE_5_CHUNKS_LEN)
 
         # read each file and verify the result
-        src_buf = self.chan.read(fh_src, SIMPLE_5_CHUNKS_LEN, 0).tostring()
+        src_buf = self.chan.read(fh_src, SIMPLE_5_CHUNKS_LEN, 0).tobytes()
         self.assertBufferEqual(src_buf, block)
-        dst_buf = chan2.read(fh_dst, SIMPLE_5_CHUNKS_LEN, 0).tostring()
+        dst_buf = chan2.read(fh_dst, SIMPLE_5_CHUNKS_LEN, 0).tobytes()
         self.assertBufferEqual(dst_buf, block)
         self.chan.close(fh_src)
         self.chan.close(fh_dst)
@@ -928,7 +928,7 @@ class TestServerSideCopy(pike.test.PikeTest):
             self.assertEqual(results[i][0][0].total_bytes_written, copy_len)
             if i < num_sess:
                 dst_buf = self.other_chan_list[i]["channel"].read(
-                    self.other_chan_list[i]["filehandles"][1], copy_len, filepair[i][2]).tostring()
+                    self.other_chan_list[i]["filehandles"][1], copy_len, filepair[i][2]).tobytes()
                 self.assertBufferEqual(dst_buf, blocks[i])
 
     def test_multiple_ssc_file(self):

--- a/pike/test/credit.py
+++ b/pike/test/credit.py
@@ -189,7 +189,7 @@ class CreditTest(pike.test.PikeTest):
             self.assertEqual(len(result), read_size)
             self.assertTrue(credit_assert_future.result())
         chan.close(fh)
-        self.assertEqual(file_buffer.tostring(), buf*file_chunks)
+        self.assertEqual(file_buffer.tobytes(), buf*file_chunks)
 
     def generic_arbitrary_mc_write_mc_read(self, file_size, write_size, read_size):
         """
@@ -348,7 +348,7 @@ class CreditTest(pike.test.PikeTest):
             self.assertTrue(credit_assert_future.result())
 
         chan.close(fh)
-        self.assertEqual(read_buffer.tostring(), file_buf)
+        self.assertEqual(read_buffer.tobytes(), file_buf)
 
 class PowerOf2CreditTest(CreditTest):
 

--- a/pike/test/multichannel.py
+++ b/pike/test/multichannel.py
@@ -88,7 +88,7 @@ class MultiChannelTest(pike.test.PikeTest):
                 chan.write(handle, 0, data_stale)
 
         # Read back data to ensure it is not stale value
-        result = chan2.read(handle, len(data_fresh), 0).tostring()
+        result = chan2.read(handle, len(data_fresh), 0).tobytes()
         self.assertEquals(result, data_fresh)
 
         # Close handle


### PR DESCRIPTION
Pave the way for py3.9 compatibility

Internal test suite is passing against 3.9-dev and 3.10-dev 🎉 

https://github.com/isi-mfurer/pike/actions/runs/129171310