### PR TITLE
pike.smb2: ChangeNotifyResponse allows STATUS_NOTIFY_CLEANUP

### DIFF
--- a/pike/smb2.py
+++ b/pike/smb2.py
@@ -3202,6 +3202,7 @@ class ChangeNotifyResponse(Response):
         Response.__init__(self, parent)
         self.notifications = []
 
+    @property
     def children(self):
         return self.notifications
 

--- a/pike/smb2.py
+++ b/pike/smb2.py
@@ -3196,6 +3196,7 @@ class FileNotifyInformation(core.Frame):
 
 class ChangeNotifyResponse(Response):
     command_id = SMB2_CHANGE_NOTIFY
+    allowed_status = [ntstatus.STATUS_SUCCESS, ntstatus.STATUS_NOTIFY_CLEANUP]
     structure_size = 9
 
     def __init__(self, parent):


### PR DESCRIPTION
[internal PSCALE-13621]

Avoid triggering ErrorResponse handling for STATUS_NOTIFY_CLEANUP. According to the specification, a Notify response with this status is not an error.

https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/f2b4183a-29c2-4fc0-a5de-fe290408f68c

# testing

https://github.com/isi-mfurer/pike/runs/762860965

(look for `test_change_notify_cancel`)