### PR TITLE
Add pytest plugin pike.conftest

### DIFF
--- a/pike/pytest_support.py
+++ b/pike/pytest_support.py
@@ -1,0 +1,67 @@
+"""Pike/pytest integration."""
+import pytest
+
+import pike.test
+
+
+# pytest API
+def pytest_configure(config):
+    """
+    register the marks so that they show up in `pytest --markers` as well as
+    not raising errors in strict marker mode
+    """
+    config.addinivalue_line(
+        "markers",
+        (
+            "require_dialect(min_dialect, max_dialect): "
+            "when using the TreeConnect fixture, if the remote server "
+            "does not advertise a dialect within the given range "
+            "then skip the test."
+        ),
+    )
+    config.addinivalue_line(
+        "markers",
+        (
+            "require_capabilities(global_capabilities): "
+            "when using the TreeConnect fixture, if the remote server "
+            "does not advertise support for all capabilities "
+            "then skip the test."
+        ),
+    )
+    config.addinivalue_line(
+        "markers",
+        (
+            "require_share_capabilities(share_capabilities): "
+            "when using the TreeConnect fixture, if the remote share "
+            "does not advertise support for all share capabilities "
+            "then skip the test."
+        ),
+    )
+
+
+def get_mark_value(item, mark_name, default):
+    for mark in item.iter_markers(name=mark_name):
+        if len(mark.args) > 1:
+            return mark.args
+        return mark.args[0]
+    return default
+
+
+@pytest.fixture
+def pike_TreeConnect(request):
+    item = request.item
+    marks = (
+        ("require_dialect", (0, float("inf"))),
+        ("require_capabilities", 0),
+        ("require_share_capabilities", 0),
+    )
+
+    def TreeConnect(*args, **kwargs):
+        # update requirements from markers
+        for mark_name, default_value in marks:
+            kwargs[mark_name] = kwargs.get(
+                mark_name, get_mark_value(item, mark_name, default_value),
+            )
+        return pike.test.TreeConnect(*args, **kwargs)
+
+    return TreeConnect

--- a/pike/pytest_support.py
+++ b/pike/pytest_support.py
@@ -49,7 +49,6 @@ def get_mark_value(item, mark_name, default):
 
 @pytest.fixture
 def pike_TreeConnect(request):
-    item = request.item
     marks = (
         ("require_dialect", (0, float("inf"))),
         ("require_capabilities", 0),
@@ -60,8 +59,11 @@ def pike_TreeConnect(request):
         # update requirements from markers
         for mark_name, default_value in marks:
             kwargs[mark_name] = kwargs.get(
-                mark_name, get_mark_value(item, mark_name, default_value),
+                mark_name, get_mark_value(request.node, mark_name, default_value),
             )
+        # special case dialect range (must be a 2-tuple)
+        if not isinstance(kwargs["require_dialect"], tuple):
+            kwargs["require_dialect"] = (kwargs["require_dialect"], float("inf"))
         return pike.test.TreeConnect(*args, **kwargs)
 
     return TreeConnect

--- a/pike/test/__init__.py
+++ b/pike/test/__init__.py
@@ -156,12 +156,14 @@ class Options(enum.Enum):
         return cls.smb2constoption(cls.PIKE_MAX_DIALECT, default=float('inf'))
 
 
-def default_client():
+def default_client(signing=None):
     client = model.Client()
     min_dialect = Options.min_dialect()
     max_dialect = Options.max_dialect()
     client.restrict_dialects(min_dialect, max_dialect)
-    if Options.signing():
+    if signing is None:
+        signing = Options.signing()
+    if signing:
         client.security_mode = (smb2.SMB2_NEGOTIATE_SIGNING_ENABLED |
                                 smb2.SMB2_NEGOTIATE_SIGNING_REQUIRED)
     return client
@@ -178,6 +180,7 @@ class TreeConnect(object):
     creds = attr.ib(factory=Options.creds)
     share = attr.ib(factory=Options.share)
     resume = attr.ib(default=None)
+    signing = attr.ib(factory=Options.signing)
     encryption = attr.ib(factory=Options.encryption)
     require_dialect = attr.ib(default=None)
     require_capabilities = attr.ib(default=None)
@@ -196,7 +199,7 @@ class TreeConnect(object):
 
     @property
     def client(self):
-        return self._client or default_client()
+        return self._client or default_client(signing=self.signing)
 
     def connect(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,7 @@ def run_setup(with_extensions):
         maintainer_email="Masen.Furer@dell.com",
         url="https://github.com/emc-isilon/pike",
         packages=["pike", "pike.test"],
+        entry_points={"pytest11": ["pike = pike.pytest_support",]},
         python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,<3.9",
         install_requires=[
             'enum34~=1.1.6;  python_version ~= "2.7"',


### PR DESCRIPTION
Expose `require_dialect`, `require_capabilities`, and `require_share_capabilities` as pytest marks.

Expose `pike_TreeConnect` fixture as entry point for establishing a pike session without a base class.

Apply require marks inside `pike_TreeConnect` fixture.