### PR TITLE
[ISILONQE-1417] Pike TimeoutError should be actionable

### DIFF
--- a/.github/workflows/test_samba.yml
+++ b/.github/workflows/test_samba.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [2.7, 3.6, 3.7, 3.8, 3.9-dev, 3.10-dev]
+        python-version: [2.7, 3.6, 3.7, 3.8, 3.9, 3.10-dev]
 
     services:
       samba:

--- a/pike/core.py
+++ b/pike/core.py
@@ -32,6 +32,7 @@
 #        Core API
 #
 # Authors: Brian Koropoff (brian.koropoff@emc.com)
+#          Masen Furer (masen.furer@dell.com)
 #
 
 """

--- a/pike/core.py
+++ b/pike/core.py
@@ -468,7 +468,8 @@ class Frame(with_metaclass(FrameMeta)):
     def __str__(self):
         return self._str(1)
 
-    def _value_str(self, value):
+    @staticmethod
+    def _value_str(value):
         if isinstance(value, array.array) and value.typecode == 'B':
             return '0x' + ''.join('%.2x' % b for b in value)
         else:

--- a/pike/model.py
+++ b/pike/model.py
@@ -32,6 +32,7 @@
 #        Transport and object model
 #
 # Authors: Brian Koropoff (brian.koropoff@emc.com)
+#          Masen Furer (masen.furer@dell.com)
 #
 
 """

--- a/pike/model.py
+++ b/pike/model.py
@@ -465,7 +465,7 @@ class Client(object):
         @param file_id: The file ID of the oplocked file.
         """
 
-        future = Future(None)
+        future = Future(request=("OplockBreak", file_id))
 
         for smb_res in self._oplock_break_queue[:]:
             if smb_res[0].file_id == file_id:
@@ -489,7 +489,7 @@ class Client(object):
         @param lease_key: The lease key for the lease.
         """
 
-        future = Future(None)
+        future = Future(request=("LeaseBreak", core.Frame._value_str(lease_key)))
 
         for smb_res in self._lease_break_queue[:]:
             if smb_res[0].lease_key == lease_key:
@@ -583,7 +583,7 @@ class Connection(transport.Transport):
         self._negotiate_request = None
         self._negotiate_response = None
         self.callbacks = {}
-        self.connection_future = Future()
+        self.connection_future = Future(request=(server, port))
         self.credits = 0
         self.client = client
         self.server = server
@@ -1045,7 +1045,7 @@ class Connection(transport.Transport):
             self.session_id = 0
             self.requests = []
             self.responses = []
-            self.session_future = Future()
+            self.session_future = Future(request=self.requests)
             self.interim_future = None
 
             if bind:
@@ -1359,7 +1359,7 @@ class Channel(object):
         return tree_req
 
     def tree_connect_submit(self, tree_req):
-        tree_future = Future()
+        tree_future = Future(request=tree_req.parent)
         resp_future = self.connection.submit(tree_req.parent.parent)[0]
         resp_future.then(lambda f: tree_future.complete(Tree(self.session,
                                                              tree_req.path,
@@ -1493,7 +1493,7 @@ class Channel(object):
             timewarp_req = smb2.TimewarpTokenRequest(create_req)
             timewarp_req.timestamp = nttime.NtTime(timewarp)
 
-        open_future = Future(None)
+        open_future = Future(request=create_req.parent)
         def finish(f):
             with open_future: open_future(
                     Open(

--- a/pike/model.py
+++ b/pike/model.py
@@ -202,12 +202,14 @@ class Future(object):
         """
         self.interim_response = response
 
-    def wait(self, timeout=default_timeout):
+    def wait(self, timeout=None):
         """
         Wait for future result to become available.
 
         @param timeout: The time in seconds before giving up and raising TimeoutError
         """
+        if timeout is None:
+            timeout = default_timeout
         deadline = time.time() + timeout
         while self.response is None:
             now = time.time()
@@ -217,12 +219,14 @@ class Future(object):
 
         return self
 
-    def wait_interim(self, timeout=default_timeout):
+    def wait_interim(self, timeout=None):
         """
         Wait for interim response or actual result to become available.
 
         @param timeout: The time in seconds before giving up and raising TimeoutError
         """
+        if timeout is None:
+            timeout = default_timeout
         deadline = time.time() + timeout
         while self.response is None and self.interim_response is None:
             now = time.time()
@@ -232,7 +236,7 @@ class Future(object):
 
         return self
 
-    def result(self, timeout=default_timeout):
+    def result(self, timeout=None):
         """
         Return result of future.
 

--- a/pike/model.py
+++ b/pike/model.py
@@ -88,7 +88,38 @@ def loop(timeout=None, count=None):
     transport.loop(timeout=timeout, count=count)
 
 class TimeoutError(Exception):
-    pass
+    """Future completion timed out"""
+    future = None
+
+    @classmethod
+    def with_future(cls, future, *args):
+        """
+        Instantiate TimeoutError from a given future.
+
+        :param future: Future that timed out
+        :param args: passed to Exception.__init__
+        :return: TimeoutError
+        """
+        ex = cls(*args)
+        ex.future = future
+        return ex
+
+    def __str__(self):
+        s = super(TimeoutError, self).__str__()
+        if self.future is not None:
+            if self.future.request is not None:
+                requests = [str(self.future.request)]
+                if not isinstance(self.future.request, (core.Frame, str, bytes)):
+                    # attempt to recursively str format other iterables
+                    try:
+                        requests = [str(r) for r in self.future.request]
+                    except TypeError:
+                        pass
+                s += "\nRequest: {}".format("\n".join(requests))
+            if self.future.interim_response is not None:
+                s += "\nInterim: {}".format(self.future.interim_response)
+        return s
+
 
 class StateError(Exception):
     pass

--- a/pike/model.py
+++ b/pike/model.py
@@ -245,7 +245,7 @@ class Future(object):
         while self.response is None:
             now = time.time()
             if now > deadline:
-                raise TimeoutError('Timed out after %s seconds' % timeout)
+                raise TimeoutError.with_future(self, 'Timed out after %s seconds' % timeout)
             loop(timeout=deadline-now, count=1)
 
         return self
@@ -262,7 +262,7 @@ class Future(object):
         while self.response is None and self.interim_response is None:
             now = time.time()
             if now > deadline:
-                raise TimeoutError('Timed out after %s seconds' % timeout)
+                raise TimeoutError.with_future(self, 'Timed out after %s seconds' % timeout)
             loop(timeout=deadline-now, count=1)
 
         return self

--- a/pike/model.py
+++ b/pike/model.py
@@ -945,10 +945,10 @@ class Connection(transport.Transport):
                     # Cancel by message id, still in send queue
                     future = [f for f in self._out_queue if f.request.message_id == smb_req.message_id][0]
                 # Add fake future for cancel since cancel has no response
-                self._out_queue.append(Future(smb_req))
+                self._out_queue.append(Future(request=smb_req))
                 futures.append(future)
             else:
-                future = Future(smb_req)
+                future = Future(request=smb_req)
                 self._out_queue.append(future)
                 futures.append(future)
 


### PR DESCRIPTION
Add context to `TimeoutError` by optionally allowing it to be raised `with_future` specified. If the `Future` has a `.request` attribute, then it will be included in the `TimeoutError` string representation.

Callers may catch the `TimeoutError` and further inspect the `.future` or even wait for it again.

Update pike's use of `Future` to include relevant "request" context information where possible.

Existing raisers of `pike.model.TimeoutError` outside of this package are unaffected as the signature and behavior of TimeoutError are backward compatible with the previous implementation.

# Testing Done

No explicit test cases are added for this change. Some scenarios were manually generated as an example and to check all code paths.

## Connect Timeout
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/git/pike/pike/test/__init__.py", line 286, in __call__
    self.connect()
  File "/git/pike/pike/test/__init__.py", line 216, in connect
    self.conn = self.client.connect(server=self.server, port=self.port).negotiate()
  File "/git/pike/pike/model.py", line 419, in connect
    return self.connect_submit(server, port).result()
  File "/git/pike/pike/model.py", line 269, in result
    self.wait(timeout)
  File "/git/pike/pike/model.py", line 239, in wait
    raise TimeoutError.with_future(self, 'Timed out after %s seconds' % timeout)
pike.model.TimeoutError: Timed out after 30 seconds
Request: ('10.7.183.206', 445)
```

## Session Setup Timeout:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/git/pike/pike/test/__init__.py", line 248, in session_setup
    self.chan = self.conn.session_setup(self.creds, resume=self.resume)
  File "/git/pike/pike/model.py", line 1235, in session_setup
    return session_context.submit().result()
  File "/git/pike/pike/model.py", line 280, in result
    self.wait(timeout)
  File "/git/pike/pike/model.py", line 248, in wait
    raise TimeoutError.with_future(self, 'Timed out after %s seconds' % timeout)
pike.model.TimeoutError: Timed out after 0.1 seconds
Request: Smb2
  credit_charge: 1
  channel_sequence: 0
  command: SMB2_SESSION_SETUP
  credit_request: 10
  flags: SMB2_FLAGS_NONE
  next_command: 0
  message_id: 1
  session_id: 0
  tree_id: 0
  signature: 0x00000000000000000000000000000000
  buf: 0xfe534d42400001000000000001000a0000000000000000000100000000000000fffe0000000000000000000000000000000000000000000000000000000000001900000100000000000000005800300000000000000000004e544c4d5353500001000000371208e00800080028000000000000003000000000000000000000004e004f004e004500
  SessionSetupRequest
    flags: 0
    security_mode: SMB2_NEGOTIATE_SIGNING_ENABLED
    capabilities: 0
    channel: 0
    previous_session_id: 0
    security_buffer: 0x4e544c4d5353500001000000371208e00800080028000000000000003000000000000000000000004e004f004e004500
    security_buffer_offset: 88
    security_buffer_length: 48
Smb2
  credit_charge: 1
  channel_sequence: 0
  command: SMB2_SESSION_SETUP
  credit_request: 10
  flags: SMB2_FLAGS_NONE
  next_command: 0
  message_id: 2
  session_id: 87152583017234869
  tree_id: 0
  signature: 0x00000000000000000000000000000000
  SessionSetupRequest
    flags: 0
    security_mode: SMB2_NEGOTIATE_SIGNING_ENABLED
    capabilities: 0
    channel: 0
    previous_session_id: 0
    security_buffer: 0x4e544c4d53535000030000001800180048000000a800a80060000000080008000801000008000800100100001200120018010000100010002a010000350289e00000000000000000a23669929e22cf9a2722b3f52301d0a24b4e77a8013e8836b783bb575e3ba0ec39ad2d9d0fe2cf340101000000000000809f80564f9bd6014b4e77a8013e88360000000002001a004d0046005300450041004e004f0044004500340032002d00310001001a004d0046005300450041004e004f0044004500340032002d00310004001a006d0066007300650061006e006f0064006500340032002d00310003001a006d0066007300650061006e006f0064006500340032002d003100000000004e004f004e00450072006f006f0074006d00660075007200650072002d0077007300eedc13d5257b261423aafee075ce3326
    security_buffer_offset: 88
    security_buffer_length: 314
```

## Tree Timeout
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/git/pike/pike/test/__init__.py", line 267, in tree_connect
    self.tree = self.chan.tree_connect(self.share)
  File "/git/pike/pike/model.py", line 1372, in tree_connect
    path)).result()
  File "/git/pike/pike/model.py", line 280, in result
    self.wait(timeout)
  File "/git/pike/pike/model.py", line 248, in wait
    raise TimeoutError.with_future(self, 'Timed out after %s seconds' % timeout)
pike.model.TimeoutError: Timed out after 0.001 seconds
Request: Smb2
  credit_charge: 1
  channel_sequence: 0
  command: SMB2_TREE_CONNECT
  credit_request: 10
  flags: SMB2_FLAGS_SIGNED
  next_command: 0
  message_id: 5
  session_id: 87152583017234872
  tree_id: 0
  signature: 0xeaa9955cb6738f07bb8a8961d3ba73bf
  TreeConnectRequest
    flags: 0
    path_offset: 72
    path_length: 36
    path: \\10.7.183.208\ifs
```

## Lease Timeout

```
*** pike.model.TimeoutError: Timed out after 0.1 seconds
Request: LeaseBreak
0x61e2400411d4d18213475283f3827820
```

## Oplock Timeout
```
E               pike.model.TimeoutError: Timed out after 0.1 seconds
E               Request: OplockBreak
E               (70026, 1)
```

## Create Timeout
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/git/pike/pike/model.py", line 280, in result
    self.wait(timeout)
  File "/git/pike/pike/model.py", line 248, in wait
    raise TimeoutError.with_future(self, 'Timed out after %s seconds' % timeout)
pike.model.TimeoutError: Timed out after 0.01 seconds
Request: Smb2
  credit_charge: 1
  channel_sequence: 0
  command: SMB2_CREATE
  credit_request: 10
  flags: SMB2_FLAGS_NONE
  next_command: 0
  message_id: 4
  session_id: 87152583017234891
  tree_id: 1
  signature: 0x00000000000000000000000000000000
  CreateRequest
    security_flags: 0
    requested_oplock_level: SMB2_OPLOCK_LEVEL_NONE
    impersonation_level: 0
    smb_create_flags: 0
    reserved: 0
    desired_access: GENERIC_WRITE | GENERIC_READ
    file_attributes: FILE_ATTRIBUTE_NORMAL
    share_access: 0
    create_disposition: FILE_OPEN_IF
    create_options: 0
    name: foo
    name_offset: 120
    name_length: 6
    create_contexts_offset: 0
    create_contexts_length: 0
    open_future: <pike.model.Future object at 0x7efe02048860>
    finish: <function Channel.create_request.<locals>.finish at 0x7efe057cb598>
```

## Write Timeout

(This one could actually contain up to 1Mb of data, yikes!)

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/git/pike/pike/model.py", line 1818, in write
    flags).parent.parent)
  File "/git/pike/pike/model.py", line 967, in transceive
    return [f.result() for f in self.submit(req)]
  File "/git/pike/pike/model.py", line 967, in <listcomp>
    return [f.result() for f in self.submit(req)]
  File "/git/pike/pike/model.py", line 280, in result
    self.wait(timeout)
  File "/git/pike/pike/model.py", line 248, in wait
    raise TimeoutError.with_future(self, 'Timed out after %s seconds' % timeout)
pike.model.TimeoutError: Timed out after 0.01 seconds
Request: Smb2
  credit_charge: 1
  channel_sequence: 0
  command: SMB2_WRITE
  credit_request: 10
  flags: SMB2_FLAGS_NONE
  next_command: 0
  message_id: 8
  session_id: 87152583017234891
  tree_id: 1
  signature: 0x00000000000000000000000000000000
  WriteRequest
    offset: 0
    file_id: (70029, 2)
    remaining_bytes: 0
    flags: 0
    buffer: b'foobarbaz'
    data_offset: 112
    length: 9
    channel: 0
    write_channel_info_offset: 0
    write_channel_info_length: 0
```

## On a Future that has received an interim response
```
E               pike.model.TimeoutError: Timed out after 10 seconds
E               Request: Smb2
E                 credit_charge: 1
E                 channel_sequence: 0
E                 command: SMB2_CREATE
E                 credit_request: 10
E                 flags: SMB2_FLAGS_NONE
E                 next_command: 0
E                 message_id: 6
E                 session_id: 87152583017234907
E                 tree_id: 1
E                 signature: 0x00000000000000000000000000000000
E                 CreateRequest
E                   security_flags: 0
E                   requested_oplock_level: SMB2_OPLOCK_LEVEL_LEASE
E                   impersonation_level: 0
E                   smb_create_flags: 0
E                   reserved: 0
E                   desired_access: GENERIC_WRITE | GENERIC_READ
E                   file_attributes: FILE_ATTRIBUTE_NORMAL
E                   share_access: FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE
E                   create_disposition: FILE_OPEN_IF
E                   create_options: 0
E                   name: lease.txt
E                   name_offset: 120
E                   name_length: 18
E                   create_contexts_offset: 0
E                   create_contexts_length: 0
E                   open_future: <pike.model.Future object at 0x7f48d2f87940>
E                   finish: <function Channel.create_request.<locals>.finish at 0x7f48d31b7d08>
E                   LeaseRequest
E                     lease_key: 0x2f84b9676a9bc7036cbbf5ada307896d
E                     lease_state: SMB2_LEASE_READ_CACHING | SMB2_LEASE_HANDLE_CACHING | SMB2_LEASE_WRITE_CACHING
E               Interim: Smb2
E                 credit_charge: 1
E                 status: STATUS_PENDING
E                 command: SMB2_CREATE
E                 credit_response: 0
E                 flags: SMB2_FLAGS_SERVER_TO_REDIR | SMB2_FLAGS_ASYNC_COMMAND
E                 next_command: 0
E                 message_id: 6
E                 async_id: 1
E                 session_id: 87152583017234907
E                 signature: 0x00000000000000000000000000000000
E                 ErrorResponse
E                   byte_count: 0
E                   error_context_count: 0
```

## Still works without a future passed:
```
>>> raise pike.model.TimeoutError("This timeout doesn't have a future")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
pike.model.TimeoutError: This timeout doesn't have a future
```