### PR TITLE
cleanup licensing headers

### DIFF
--- a/.github/workflows/publishpackage.yml
+++ b/.github/workflows/publishpackage.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2020, Dell Inc. or its subsidiaries.
+# All rights reserved.
+# See file LICENSE for licensing information.
+---
 name: Upload Python Package
 
 on:

--- a/.github/workflows/test_samba.yml
+++ b/.github/workflows/test_samba.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2020, Dell Inc. or its subsidiaries.
+# All rights reserved.
+# See file LICENSE for licensing information.
+---
 name: Run tests against samba
 
 on: [push, pull_request]

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 Pike, with the exception of pykerb and certain build scripts
-(see below) is licensed under the following terms:
+(see below), is licensed under Simplified BSD License as follows:
 
-  Copyright (c) 2013, EMC Corporation
+  Copyright © 2013-2020, Dell Inc. or its subsidiaries.
   All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
@@ -27,7 +27,7 @@ Pike, with the exception of pykerb and certain build scripts
 
 pykerb is licensed under the terms of the Apache 2.0 license as follows:
 
-  Copyright (c) 2006-2009 Apple Inc. All rights reserved.
+  Copyright © 2006-2009 Apple Inc. All rights reserved.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ with a pcap analysis tool.
 
 ---
 
-This project, _pike_, is released under a Simplified BSD License granted by Dell Inc.'s Open Source Project program,
+This project, _pike_ and _pike-smb2_, is released under a Simplified BSD License granted by Dell Inc.'s Open Source Project program,
 except code under `pykerb/` which is released under an Apache 2.0 License granted by Apple Inc.
 All project contributions are entirely reflective of the respective author(s) and not of Dell Inc. or Apple Inc.
 See [LICENSE](LICENSE) for licensing information.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@ Pike
 ====
 
 Pike is a (nearly) pure-Python framework for writing SMB2/3 protocol correctness tests.
-See [LICENSE](LICENSE) for licensing information.
 
 There is also [API documentation from epydoc](http://emc-isilon.github.io/pike/api/index.html).
 
@@ -133,3 +132,10 @@ with a pcap analysis tool.
 * `od` dumps the output to a format [wireshark can read](https://www.wireshark.org/docs/wsug_html_chunked/ChIOImportSection.html)
 * `text2pcap` (wireshark) appends fake ethernet and IP headers to the SMB packet and writes a pcap file to stdout
 * `tshark` (wireshark) decodes the SMB packet and displays full packet details
+
+---
+
+This project, _pike_, is released under a Simplified BSD License granted by Dell Inc.'s Open Source Project program,
+except code under `pykerb/` which is released under an Apache 2.0 License granted by Apple Inc.
+All project contributions are entirely reflective of the respective author(s) and not of Dell Inc. or Apple Inc.
+See [LICENSE](LICENSE) for licensing information.

--- a/doc/class-hierarchy.dot
+++ b/doc/class-hierarchy.dot
@@ -3,6 +3,7 @@
    All rights reserved.
    See file LICENSE for licensing information.
 */
+
 digraph hierarchy {
 	rankdir = BT
 	Frame [style=dashed]

--- a/doc/class-hierarchy.dot
+++ b/doc/class-hierarchy.dot
@@ -1,3 +1,8 @@
+/*
+   Copyright (c) 2013-2020, Dell Inc. or its subsidiaries.
+   All rights reserved.
+   See file LICENSE for licensing information.
+*/
 digraph hierarchy {
 	rankdir = BT
 	Frame [style=dashed]

--- a/doc/container-model.dot
+++ b/doc/container-model.dot
@@ -1,3 +1,8 @@
+/*
+   Copyright (c) 2013-2020, Dell Inc. or its subsidiaries.
+   All rights reserved.
+   See file LICENSE for licensing information.
+*/
 digraph request {
 	Smb2a [label="Smb2[0]"]
 	Smb2b [label="Smb2[1]"]

--- a/doc/container-model.dot
+++ b/doc/container-model.dot
@@ -3,6 +3,7 @@
    All rights reserved.
    See file LICENSE for licensing information.
 */
+
 digraph request {
 	Smb2a [label="Smb2[0]"]
 	Smb2b [label="Smb2[1]"]

--- a/doc/object-model.dot
+++ b/doc/object-model.dot
@@ -1,3 +1,8 @@
+/*
+   Copyright (c) 2013-2020, Dell Inc. or its subsidiaries.
+   All rights reserved.
+   See file LICENSE for licensing information.
+*/
 digraph model {
 	layout=neato
 	overlap=false

--- a/doc/object-model.dot
+++ b/doc/object-model.dot
@@ -3,6 +3,7 @@
    All rights reserved.
    See file LICENSE for licensing information.
 */
+
 digraph model {
 	layout=neato
 	overlap=false

--- a/pike/__init__.py
+++ b/pike/__init__.py
@@ -1,3 +1,8 @@
+
+# Copyright (c) 2016-2020, Dell Inc. or its subsidiaries.
+# All rights reserved.
+# See file LICENSE for licensing information.
+
 import six
 if six.PY2:
     import array

--- a/pike/__init__.py
+++ b/pike/__init__.py
@@ -1,7 +1,8 @@
-
+#
 # Copyright (c) 2016-2020, Dell Inc. or its subsidiaries.
 # All rights reserved.
 # See file LICENSE for licensing information.
+#
 
 import six
 if six.PY2:

--- a/pike/auth.py
+++ b/pike/auth.py
@@ -1,27 +1,7 @@
 #
-# Copyright (c) 2016, Dell Technologies
+# Copyright (c) 2016-2020, Dell Inc. or its subsidiaries.
 # All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice,
-# this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# See file LICENSE for licensing information.
 #
 # Module Name:
 #

--- a/pike/auth.py
+++ b/pike/auth.py
@@ -19,8 +19,8 @@ Authentication Plugins for Pike
 
 This module contains wrappers around external authentication mechanisms and APIs.
 """
-from __future__ import absolute_import
 
+from __future__ import absolute_import
 
 from builtins import object
 import array

--- a/pike/core.py
+++ b/pike/core.py
@@ -1,27 +1,7 @@
 #
-# Copyright (c) 2013, EMC Corporation
+# Copyright (c) 2013-2020, Dell Inc. or its subsidiaries.
 # All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice,
-# this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# See file LICENSE for licensing information.
 #
 # Module Name:
 #

--- a/pike/crypto.py
+++ b/pike/crypto.py
@@ -13,6 +13,7 @@
 #
 # Authors: Masen Furer (masen.furer@dell.com)
 #
+
 from __future__ import absolute_import
 from builtins import map
 from builtins import range

--- a/pike/crypto.py
+++ b/pike/crypto.py
@@ -1,27 +1,7 @@
 #
-# Copyright (c) 2016, EMC Corporation
+# Copyright (c) 2016-2020, Dell Inc. or its subsidiaries.
 # All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice,
-# this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# See file LICENSE for licensing information.
 #
 # Module Name:
 #

--- a/pike/digest.py
+++ b/pike/digest.py
@@ -1,27 +1,7 @@
 #
-# Copyright (c) 2013, EMC Corporation
+# Copyright (c) 2013-2020, Dell Inc. or its subsidiaries.
 # All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice,
-# this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# See file LICENSE for licensing information.
 #
 # Module Name:
 #

--- a/pike/digest.py
+++ b/pike/digest.py
@@ -13,6 +13,7 @@
 #
 # Authors: Brian Koropoff (brian.koropoff@emc.com)
 #
+
 from __future__ import absolute_import
 from __future__ import division
 from builtins import range

--- a/pike/model.py
+++ b/pike/model.py
@@ -24,6 +24,7 @@ to be established and tracked.  It provides convenience functions
 for exercising common elements of the protocol without manually
 constructing packets.
 """
+
 from __future__ import absolute_import
 from builtins import next
 from builtins import map

--- a/pike/model.py
+++ b/pike/model.py
@@ -1,27 +1,7 @@
 #
-# Copyright (c) 2013, EMC Corporation
+# Copyright (c) 2013-2020, Dell Inc. or its subsidiaries.
 # All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice,
-# this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# See file LICENSE for licensing information.
 #
 # Module Name:
 #

--- a/pike/netbios.py
+++ b/pike/netbios.py
@@ -1,27 +1,7 @@
 #
-# Copyright (c) 2013, EMC Corporation
+# Copyright (c) 2013-2020, Dell Inc. or its subsidiaries.
 # All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice,
-# this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# See file LICENSE for licensing information.
 #
 # Module Name:
 #

--- a/pike/netbios.py
+++ b/pike/netbios.py
@@ -20,6 +20,7 @@ from . import core
 from . import crypto
 from . import smb2
 
+
 class Netbios(core.Frame):
     LOG_CHILDREN_COUNT = False
     LOG_CHILDREN_EXPAND = True

--- a/pike/netbios.py
+++ b/pike/netbios.py
@@ -13,6 +13,7 @@
 #
 # Authors: Brian Koropoff (brian.koropoff@emc.com)
 #
+
 from __future__ import absolute_import
 
 from . import core

--- a/pike/ntlm.py
+++ b/pike/ntlm.py
@@ -13,6 +13,7 @@
 #
 # Authors: Masen Furer (masen.furer@emc.com)
 #
+
 from __future__ import absolute_import
 from builtins import object
 from builtins import range

--- a/pike/ntlm.py
+++ b/pike/ntlm.py
@@ -1,27 +1,7 @@
 #
-# Copyright (c) 2013, EMC Corporation
+# Copyright (c) 2013-2020, Dell Inc. or its subsidiaries.
 # All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice,
-# this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# See file LICENSE for licensing information.
 #
 # Module Name:
 #

--- a/pike/ntstatus.py
+++ b/pike/ntstatus.py
@@ -7,6 +7,7 @@
 from __future__ import absolute_import
 from . import core
 
+
 class Status(core.ValueEnum):
     STATUS_SUCCESS = 0x00000000
     #STATUS_WAIT_0 = 0x00000000
@@ -1801,5 +1802,6 @@ class Status(core.ValueEnum):
     STATUS_VHD_CHILD_PARENT_SIZE_MISMATCH = 0xC03A0017
     STATUS_VHD_DIFFERENCING_CHAIN_CYCLE_DETECTED = 0xC03A0018
     STATUS_VHD_DIFFERENCING_CHAIN_ERROR_IN_PARENT = 0xC03A0019
+
 
 Status.import_items(globals())

--- a/pike/ntstatus.py
+++ b/pike/ntstatus.py
@@ -1,3 +1,9 @@
+#
+# Copyright (c) 2013-2020, Dell Inc. or its subsidiaries.
+# All rights reserved.
+# See file LICENSE for licensing information.
+#
+
 from __future__ import absolute_import
 from . import core
 

--- a/pike/nttime.py
+++ b/pike/nttime.py
@@ -1,27 +1,7 @@
 #
-# Copyright (c) 2013, EMC Corporation
+# Copyright (c) 2013-2020, Dell Inc. or its subsidiaries.
 # All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice,
-# this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# See file LICENSE for licensing information.
 #
 # Module Name:
 #

--- a/pike/nttime.py
+++ b/pike/nttime.py
@@ -14,6 +14,7 @@
 # Authors: Rafal Szczesniak (rafal.szczesniak@isilon.com)
 #          Masen Furer (masen.furer@dell.com)
 #
+
 from __future__ import division
 from builtins import str
 from past.builtins import basestring

--- a/pike/nttime.py
+++ b/pike/nttime.py
@@ -27,15 +27,19 @@ _unix_time_offset = 11644473600
 _unix_epoch = datetime.fromtimestamp(0) + timedelta(hours=time.localtime().tm_isdst)
 _intervals_per_second = 10000000
 
+
 def _unix_time_to_nt_time(t):
     return (t + _unix_time_offset) * _intervals_per_second
+
 
 def _datetime_to_unix_time(t):
     td = (t - _unix_epoch)
     return td.seconds + (td.days * 24 * 3600)
 
+
 def _datetime_to_nt_time(t):
     return _unix_time_to_nt_time(_datetime_to_unix_time(t))
+
 
 def _nt_time_to_unix_time(t):
     """
@@ -57,6 +61,7 @@ def _nt_time_to_unix_time(t):
     py_time += math.copysign(py_time_parts[1], py_time) // (2 ** 32)
     return py_time
 
+
 def GMT_to_datetime(gmt_token):
     dt_obj = datetime.strptime(
             gmt_token,
@@ -64,6 +69,7 @@ def GMT_to_datetime(gmt_token):
     # apply timezone conversion
     dt_obj -= timedelta(seconds=time.timezone)
     return dt_obj
+
 
 class NtTime(int):
     """

--- a/pike/pytest_support.py
+++ b/pike/pytest_support.py
@@ -5,6 +5,7 @@
 #
 
 """Pike/pytest integration."""
+
 import pytest
 
 import pike.test

--- a/pike/pytest_support.py
+++ b/pike/pytest_support.py
@@ -1,3 +1,9 @@
+#
+# Copyright (c) 2020, Dell Inc. or its subsidiaries.
+# All rights reserved.
+# See file LICENSE for licensing information.
+#
+
 """Pike/pytest integration."""
 import pytest
 

--- a/pike/smb2.py
+++ b/pike/smb2.py
@@ -25,6 +25,7 @@ making it PEP-8 compliant. For example, FooBarBaz becomes foo_bar_baz.
 This makes it simple to correlate the code with the spec while
 maintaining a clear visual distinction between values and types.
 """
+
 from __future__ import absolute_import
 from builtins import str
 from builtins import range
@@ -36,6 +37,7 @@ from . import core
 from . import nttime
 from . import ntstatus
 
+
 # Dialects constants
 class Dialect(core.ValueEnum):
     DIALECT_SMB2_WILDCARD = 0x02FF
@@ -45,7 +47,9 @@ class Dialect(core.ValueEnum):
     DIALECT_SMB3_0_2      = 0x0302
     DIALECT_SMB3_1_1      = 0x0311
 
+
 Dialect.import_items(globals())
+
 
 # Flag constants
 class Flags(core.FlagEnum):
@@ -57,7 +61,9 @@ class Flags(core.FlagEnum):
     SMB2_FLAGS_DFS_OPERATIONS     = 0x10000000
     SMB2_FLAGS_REPLAY_OPERATION   = 0x20000000
 
+
 Flags.import_items(globals())
+
 
 # Command constants
 class CommandId(core.ValueEnum):
@@ -81,7 +87,9 @@ class CommandId(core.ValueEnum):
     SMB2_SET_INFO        = 0x0011
     SMB2_OPLOCK_BREAK    = 0x0012
 
+
 CommandId.import_items(globals())
+
 
 # Share Capabilities
 class ShareCaps(core.FlagEnum):
@@ -90,7 +98,9 @@ class ShareCaps(core.FlagEnum):
     SMB2_SHARE_CAP_SCALEOUT                = 0x00000020
     SMB2_SHARE_CAP_CLUSTER                 = 0x00000040
 
+
 ShareCaps.import_items(globals())
+
 
 # Share flags
 class ShareFlags(core.FlagEnum):
@@ -108,6 +118,7 @@ class ShareFlags(core.FlagEnum):
     SMB2_SHAREFLAG_ENABLE_HASH_V1 = 0x00002000
     SMB2_SHAREFLAG_ENABLE_HASH_V2 = 0x00004000
     SMB2_SHAREFLAG_ENCRYPT_DATA = 0x00008000
+
 
 ShareFlags.import_items(globals())
 
@@ -300,6 +311,7 @@ class Smb2(core.Frame):
             if signature != self.signature:
                 raise core.BadPacket()
 
+
 class Command(core.Frame):
     def __init__(self, parent):
         core.Frame.__init__(self, parent)
@@ -319,13 +331,16 @@ class Command(core.Frame):
 class Request(Command):
     pass
 
+
 @Smb2.response
 class Response(Command):
     allowed_status = [ntstatus.STATUS_SUCCESS]
 
+
 @Smb2.notification
 class Notification(Command):
     pass
+
 
 class ErrorResponse(Command):
     structure_size = 9
@@ -402,15 +417,19 @@ class ErrorResponseContext(core.Frame):
         if parent is not None:
             parent.append(self)
 
+
 class ErrorResponseDefault(ErrorResponseContext):
     error_id = SMB2_ERROR_ID_DEFAULT
     parent_status = None
+
     def _decode(self, cur):
         self.error_data = cur.decode_bytes(self.data_length)
+
 
 class ErrorResponseDefaultBufferSize(ErrorResponseContext):
     error_id = SMB2_ERROR_ID_DEFAULT
     parent_status = ntstatus.STATUS_BUFFER_TOO_SMALL
+
     def _decode(self, cur):
         self.error_data = cur.decode_uint32le()
         self.minimum_buffer_length = self.error_data
@@ -418,6 +437,7 @@ class ErrorResponseDefaultBufferSize(ErrorResponseContext):
 class SymbolicLinkErrorResponse(ErrorResponseContext):
     error_id = SMB2_ERROR_ID_DEFAULT
     parent_status = ntstatus.STATUS_STOPPED_ON_SYMLINK
+
     def _decode(self, cur):
         end = cur + self.data_length
         self.sym_link_length = cur.decode_uint32le()
@@ -430,6 +450,7 @@ class SymbolicLinkErrorResponse(ErrorResponseContext):
             self.error_data = reparse_data(self)
             self.error_data.decode(cur)
 
+
 class Cancel(Request):
     command_id = SMB2_CANCEL
     structure_size = 4
@@ -438,13 +459,16 @@ class Cancel(Request):
         # Reserved
         cur.encode_uint16le(0)
 
+
 # Negotiate constants
 class SecurityMode(core.FlagEnum):
     SMB2_NEGOTIATE_NONE             = 0x0000
     SMB2_NEGOTIATE_SIGNING_ENABLED  = 0x0001
     SMB2_NEGOTIATE_SIGNING_REQUIRED = 0x0002
 
+
 SecurityMode.import_items(globals())
+
 
 class GlobalCaps(core.FlagEnum):
     SMB2_GLOBAL_CAP_DFS                = 0x00000001
@@ -455,18 +479,24 @@ class GlobalCaps(core.FlagEnum):
     SMB2_GLOBAL_CAP_DIRECTORY_LEASING  = 0x00000020
     SMB2_GLOBAL_CAP_ENCRYPTION         = 0x00000040
 
+
 GlobalCaps.import_items(globals())
+
 
 class NegotiateContextType(core.ValueEnum):
     SMB2_PREAUTH_INTEGRITY_CAPABILITIES = 0x0001
     SMB2_ENCRYPTION_CAPABILITIES = 0x0002
 
+
 NegotiateContextType.import_items(globals())
+
 
 class HashAlgorithms(core.ValueEnum):
     SMB2_SHA_512 = 0x0001
 
+
 HashAlgorithms.import_items(globals())
+
 
 class NegotiateRequest(Request):
     command_id = SMB2_NEGOTIATE
@@ -530,6 +560,7 @@ class NegotiateRequest(Request):
 
     def append(self, e):
         self.negotiate_contexts.append(e)
+
 
 class NegotiateResponse(Response):
     command_id = SMB2_NEGOTIATE
@@ -599,6 +630,7 @@ class NegotiateResponse(Response):
     def append(self, e):
         self.negotiate_contexts.append(e)
 
+
 class NegotiateRequestContext(core.Frame):
     def __init__(self, parent):
         core.Frame.__init__(self, parent)
@@ -606,20 +638,25 @@ class NegotiateRequestContext(core.Frame):
             parent.append(self)
         self.data_length = None
 
+
 @NegotiateResponse.negotiate_context
 class NegotiateResponseContext(core.Frame):
+
     def __init__(self, parent):
         core.Frame.__init__(self, parent)
         if parent is not None:
             parent.append(self)
 
+
 class PreauthIntegrityCapabilities(core.Frame):
     context_type = SMB2_PREAUTH_INTEGRITY_CAPABILITIES
+
     def __init__(self):
         self.hash_algorithms = []
         self.hash_algorithms_count = None
         self.salt = b""
         self.salt_length = None
+
     def _encode(self, cur):
         if self.hash_algorithms_count is None:
             self.hash_algorithms_count = len(self.hash_algorithms)
@@ -630,6 +667,7 @@ class PreauthIntegrityCapabilities(core.Frame):
         for h in self.hash_algorithms:
             cur.encode_uint16le(h)
         cur.encode_bytes(self.salt)
+
     def _decode(self, cur):
         self.hash_algorithm_count = cur.decode_uint16le()
         self.salt_length = cur.decode_uint16le()
@@ -637,17 +675,20 @@ class PreauthIntegrityCapabilities(core.Frame):
             self.hash_algorithms.append(HashAlgorithms(cur.decode_uint16le()))
         self.salt = cur.decode_bytes(self.salt_length)
 
+
 class PreauthIntegrityCapabilitiesRequest(NegotiateRequestContext,
                                           PreauthIntegrityCapabilities):
     def __init__(self, parent):
         NegotiateRequestContext.__init__(self, parent)
         PreauthIntegrityCapabilities.__init__(self)
 
+
 class PreauthIntegrityCapabilitiesResponse(NegotiateResponseContext,
                                            PreauthIntegrityCapabilities):
     def __init__(self, parent):
         NegotiateResponseContext.__init__(self, parent)
         PreauthIntegrityCapabilities.__init__(self)
+
 
 # Session setup constants
 class SessionFlags(core.FlagEnum):
@@ -656,7 +697,9 @@ class SessionFlags(core.FlagEnum):
     SMB2_SESSION_FLAG_IS_NULL = 0x02
     SMB2_SESSION_FLAG_ENCRYPT_DATA = 0x04
 
+
 SessionFlags.import_items(globals())
+
 
 # SMB2_ECHO_REQUEST definition
 class EchoRequest(Request):
@@ -671,6 +714,7 @@ class EchoRequest(Request):
         # Reserved
         cur.encode_uint16le(self.reserved)
 
+
 # SMB2_ECHO_RESPONSE definition
 class EchoResponse(Response):
     # Expect response whenever SMB2_ECHO_REQUEST sent
@@ -683,6 +727,7 @@ class EchoResponse(Response):
     def _decode(self, cur):
         # Reserved
         cur.decode_uint16le()
+
 
 # SMB2_FLUSH_REQUEST definition
 class FlushRequest(Request):
@@ -703,6 +748,7 @@ class FlushRequest(Request):
         cur.encode_uint64le(self.file_id[0])
         cur.encode_uint64le(self.file_id[1])
 
+
 # SMB2_FLUSH_RESPONSE definition
 class FlushResponse(Response):
     # Expect response whenever SMB2_FLUSH_REQUEST sent
@@ -714,6 +760,7 @@ class FlushResponse(Response):
 
     def _decode(self, cur):
         self.reserved = cur.decode_uint16le()
+
 
 class SessionSetupRequest(Request):
     command_id = SMB2_SESSION_SETUP
@@ -747,6 +794,7 @@ class SessionSetupRequest(Request):
         sec_buf_ofs(self.security_buffer_offset)
         cur.encode_bytes(self.security_buffer)
 
+
 class SessionSetupResponse(Response):
     command_id = SMB2_SESSION_SETUP
     allowed_status = [ntstatus.STATUS_SUCCESS, ntstatus.STATUS_MORE_PROCESSING_REQUIRED]
@@ -765,6 +813,7 @@ class SessionSetupResponse(Response):
         # Advance to sec buffer
         cur.advanceto(self.parent.start + offset)
         self.security_buffer = cur.decode_bytes(length)
+
 
 class TreeConnectRequest(Request):
     command_id = SMB2_TREE_CONNECT
@@ -836,6 +885,7 @@ class TreeConnectResponse(Response):
         self.capabilities = cur.decode_uint32le()
         self.maximal_access = Access(cur.decode_uint32le())
 
+
 class TreeDisconnectRequest(Request):
     command_id = SMB2_TREE_DISCONNECT
     structure_size = 4
@@ -846,6 +896,7 @@ class TreeDisconnectRequest(Request):
     def _encode(self, cur):
         # Reserved
         cur.encode_uint16le(0)
+
 
 class TreeDisconnectResponse(Response):
     command_id = SMB2_TREE_DISCONNECT
@@ -858,6 +909,7 @@ class TreeDisconnectResponse(Response):
         # Ignore reserved
         cur.decode_uint16le()
 
+
 class LogoffRequest(Request):
     command_id = SMB2_LOGOFF
     structure_size = 4
@@ -868,6 +920,7 @@ class LogoffRequest(Request):
     def _encode(self, cur):
         # Reserved
         cur.encode_uint16le(0)
+
 
 class LogoffResponse(Response):
     command_id = SMB2_LOGOFF
@@ -880,6 +933,7 @@ class LogoffResponse(Response):
         # Ignore reserved
         cur.decode_uint16le()
 
+
 # Oplock levels
 class OplockLevel(core.ValueEnum):
     SMB2_OPLOCK_LEVEL_NONE      = 0x00
@@ -888,7 +942,9 @@ class OplockLevel(core.ValueEnum):
     SMB2_OPLOCK_LEVEL_BATCH     = 0x09
     SMB2_OPLOCK_LEVEL_LEASE     = 0xFF
 
+
 OplockLevel.import_items(globals())
+
 
 # Share access
 class ShareAccess(core.FlagEnum):
@@ -896,11 +952,13 @@ class ShareAccess(core.FlagEnum):
     FILE_SHARE_WRITE  = 0x00000002
     FILE_SHARE_DELETE = 0x00000004
 
+
 ShareAccess.import_items(globals())
 
 FILE_SHARE_ALL = (
     FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE
 )
+
 
 # Create dispositions
 class CreateDisposition(core.ValueEnum):
@@ -911,7 +969,9 @@ class CreateDisposition(core.ValueEnum):
     FILE_OVERWRITE    = 0x00000004
     FILE_OVERWRITE_IF = 0x00000005
 
+
 CreateDisposition.import_items(globals())
+
 
 # Create options
 class CreateOptions(core.FlagEnum):
@@ -934,7 +994,9 @@ class CreateOptions(core.FlagEnum):
     FILE_OPEN_NO_RECALL            = 0x00400000
     FILE_OPEN_FOR_FREE_SPACE_QUERY = 0x00800000
 
+
 CreateOptions.import_items(globals())
+
 
 # Access masks
 class Access(core.FlagEnum):
@@ -963,7 +1025,9 @@ class Access(core.FlagEnum):
     FILE_TRAVERSE           = 0x00000020
     FILE_DELETE_CHILD       = 0x00000040
 
+
 Access.import_items(globals())
+
 
 # File attributes
 class FileAttributes(core.FlagEnum):
@@ -982,7 +1046,9 @@ class FileAttributes(core.FlagEnum):
     FILE_ATTRIBUTE_NOT_CONTENT_INDEXED   = 0x00002000
     FILE_ATTRIBUTE_ENCRYPTED             = 0x00004000
 
+
 FileAttributes.import_items(globals())
+
 
 class CreateRequest(Request):
     command_id = SMB2_CREATE
@@ -1103,6 +1169,7 @@ class CreateRequest(Request):
     def append(self, e):
         self._create_contexts.append(e)
 
+
 class CreateResponse(Response):
     command_id = SMB2_CREATE
     structure_size = 89
@@ -1185,11 +1252,13 @@ class CreateResponse(Response):
     def append(self, e):
         self._create_contexts.append(e)
 
+
 class CreateRequestContext(core.Frame):
     def __init__(self, parent):
         core.Frame.__init__(self, parent)
         if parent is not None:
             parent.append(self)
+
 
 @CreateResponse.create_context
 class CreateResponseContext(core.Frame):
@@ -1197,6 +1266,7 @@ class CreateResponseContext(core.Frame):
         core.Frame.__init__(self, parent)
         if parent is not None:
             parent.append(self)
+
 
 class MaximalAccessRequest(CreateRequestContext):
     name = b'MxAc'
@@ -1209,6 +1279,7 @@ class MaximalAccessRequest(CreateRequestContext):
         if self.timestamp is not None:
             cur.encode_uint64le(self.timestamp)
 
+
 class MaximalAccessResponse(CreateResponseContext):
     name = b'MxAc'
 
@@ -1220,6 +1291,7 @@ class MaximalAccessResponse(CreateResponseContext):
     def _decode(self, cur):
         self.query_status = ntstatus.Status(cur.decode_uint32le())
         self.maximal_access = Access(cur.decode_uint32le())
+
 
 class AllocationSizeRequest(CreateRequestContext):
     name = b'AlSi'
@@ -1256,11 +1328,13 @@ class ExtendedAttributeRequest(CreateRequestContext):
             cur.encode_bytes(self.ea_name)
             cur.encode_bytes(self.ea_value)
 
+
 class LeaseState(core.FlagEnum):
     SMB2_LEASE_NONE           = 0x00
     SMB2_LEASE_READ_CACHING   = 0x01
     SMB2_LEASE_HANDLE_CACHING = 0x02
     SMB2_LEASE_WRITE_CACHING  = 0x04
+
 
 LeaseState.import_items(globals())
 
@@ -1269,11 +1343,14 @@ SMB2_LEASE_RH = SMB2_LEASE_R | SMB2_LEASE_HANDLE_CACHING
 SMB2_LEASE_RW = SMB2_LEASE_R | SMB2_LEASE_WRITE_CACHING
 SMB2_LEASE_RWH = SMB2_LEASE_RH | SMB2_LEASE_RW
 
+
 class LeaseFlags(core.FlagEnum):
     SMB2_LEASE_FLAG_NONE              = 0x00
     SMB2_LEASE_FLAG_BREAK_IN_PROGRESS = 0x02
 
+
 LeaseFlags.import_items(globals())
+
 
 class SecDescControl(core.FlagEnum):
     SR    = 0x0001
@@ -1292,6 +1369,7 @@ class SecDescControl(core.FlagEnum):
     DP    = 0x2000
     GD    = 0x4000
     OD    = 0x8000
+
 
 class AceType(core.ValueEnum):
     ACCESS_ALLOWED_ACE_TYPE                  = 0x00
@@ -1326,13 +1404,17 @@ class AceFlags(core.FlagEnum):
     SUCCESSFUL_ACCESS_ACE_FLAG = 0x40
     FAILED_ACCESS_ACE_FLAG     = 0x80
 
+
 AceFlags.import_items(globals())
+
 
 class AclRevision(core.ValueEnum):
     ACL_REVISION    = 0x02
     ACL_REVISION_DS = 0x04
 
+
 AclRevision.import_items(globals())
+
 
 class SecurityDescriptorRequest(CreateRequestContext):
     name = b'SecD'
@@ -1501,6 +1583,7 @@ class SecurityDescriptorRequest(CreateRequestContext):
                         owner_sid_size[0] + group_sid_size[0] + sacl_size[2]
         return off_owner,off_group,off_sacl,off_dacl
 
+
 class NT_ACL(core.Frame):
 
     def __init__(self):
@@ -1569,6 +1652,7 @@ class NT_ACL(core.Frame):
         if self.ace_count == -1:
             self.ace_count = len(self._entries)
         acl_count_hole(self.ace_count)
+
 
 class NT_ACE(core.Frame):
 
@@ -1688,8 +1772,10 @@ class NT_SID(core.Frame):
             self.sub_authority_count = len(self.sub_authority)
         subauth_count_hole(self.sub_authority_count)
 
+
 class LeaseRequest(CreateRequestContext):
     name = b'RqLs'
+
     # This class handles V2 requests as well.  Set
     # the lease_flags field to a non-None value
     # to enable the extended fields
@@ -1756,10 +1842,13 @@ class LeaseResponse(CreateResponseContext):
             self.parent_lease_key = None
             self.epoch = None
 
+
 class DurableFlags(core.FlagEnum):
     SMB2_DHANDLE_FLAG_PERSISTENT = 0x02
 
+
 DurableFlags.import_items(globals())
+
 
 class DurableHandleRequest(CreateRequestContext):
     name = b'DHnQ'
@@ -1809,6 +1898,7 @@ class DurableHandleV2Request(CreateRequestContext):
         cur.encode_uint64le(0)
         cur.encode_bytes(self.create_guid)
 
+
 class DurableHandleV2Response(CreateResponseContext):
     name = b'DH2Q'
 
@@ -1820,6 +1910,7 @@ class DurableHandleV2Response(CreateResponseContext):
     def _decode(self, cur):
         self.timeout = cur.decode_uint32le()
         self.flags = DurableFlags(cur.decode_uint32le())
+
 
 class DurableHandleReconnectV2Request(CreateRequestContext):
     name = b'DH2C'
@@ -1835,6 +1926,7 @@ class DurableHandleReconnectV2Request(CreateRequestContext):
         cur.encode_uint64le(self.file_id[1])
         cur.encode_bytes(self.create_guid)
         cur.encode_uint32le(self.flags)
+
 
 class AppInstanceIdRequest(CreateRequestContext):
     name = b'\x45\xBC\xA6\x6A\xEF\xA7\xF7\x4A\x90\x08\xFA\x46\x2E\x14\x4D\x74'
@@ -1859,6 +1951,7 @@ class QueryOnDiskIDRequest(CreateRequestContext):
     def _encode(self, cur):
         pass           # client sends no data to server
 
+
 class QueryOnDiskIDResponse(CreateResponseContext):
     name = b'QFid'
 
@@ -1868,6 +1961,7 @@ class QueryOnDiskIDResponse(CreateResponseContext):
 
     def _decode(self, cur):
         self.file_id = cur.decode_bytes(32)
+
 
 class TimewarpTokenRequest(CreateRequestContext):
     name = b'TWrp'
@@ -1904,10 +1998,13 @@ class CloseRequest(Request):
         cur.encode_uint64le(self.file_id[0])
         cur.encode_uint64le(self.file_id[1])
 
+
 class CloseFlags(core.FlagEnum):
     SMB2_CLOSE_FLAG_POSTQUERY_ATTRIB = 0x0001
 
+
 CloseFlags.import_items(globals())
+
 
 class CloseResponse(Response):
     command_id = SMB2_CLOSE
@@ -1934,6 +2031,7 @@ class CloseResponse(Response):
         self.allocation_size = cur.decode_uint64le()
         self.end_of_file = cur.decode_uint64le()
         self.file_attributes = FileAttributes(cur.decode_uint32le())
+
 
 class FileInformationClass(core.ValueEnum):
     FILE_SECURITY_INFORMATION = 0
@@ -2018,6 +2116,7 @@ class QueryDirectoryRequest(Request):
         cur.encode_utf16le(self.file_name)
         file_name_length_hole(cur - file_name_start)
 
+
 class QueryDirectoryResponse(Response):
     command_id = SMB2_QUERY_DIRECTORY
     structure_size = 9
@@ -2072,13 +2171,16 @@ class QueryDirectoryResponse(Response):
         else:
             Information(self, end).decode(cur)
 
+
 class InfoType(core.ValueEnum):
     SMB2_0_INFO_FILE       = 0x01
     SMB2_0_INFO_FILESYSTEM = 0x02
     SMB2_0_INFO_SECURITY   = 0x03
     SMB2_0_INFO_QUOTA      = 0x04
 
+
 InfoType.import_items(globals())
+
 
 class SecurityInformation(core.FlagEnum):
     OWNER_SECURITY_INFORMATION = 0x00000001
@@ -2087,14 +2189,18 @@ class SecurityInformation(core.FlagEnum):
     SACL_SECURITY_INFORMATION = 0x00000008
     ATTRIBUTE_SECURITY_INFORMATION = 0x00000020
 
+
 SecurityInformation.import_items(globals())
+
 
 class ScanFlags(core.FlagEnum):
     SL_RESTART_SCAN        = 0x00000001
     SL_RETURN_SINGLE_ENTRY = 0x00000002
     SL_INDEX_SPECIFIED     = 0x00000004
 
+
 ScanFlags.import_items(globals())
+
 
 class QueryInfoRequest(Request):
     command_id = SMB2_QUERY_INFO
@@ -2287,9 +2393,11 @@ class Information(core.Frame):
 class FileInformation(Information):
     info_type = SMB2_0_INFO_FILE
 
+
 @QueryInfoResponse.information
 class FileSystemInformation(Information):
     info_type = SMB2_0_INFO_FILESYSTEM
+
 
 class FileSecurityInformation(FileInformation):
     file_information_class = FILE_SECURITY_INFORMATION
@@ -2418,6 +2526,7 @@ class FileSecurityInformation(FileInformation):
             dacl_ofs(self.offset_dacl)
             self.dacl.encode(cur)
 
+
 class FileAccessInformation(FileInformation):
     file_information_class = FILE_ACCESS_INFORMATION
 
@@ -2427,6 +2536,7 @@ class FileAccessInformation(FileInformation):
 
     def _decode(self, cur):
         self.access_flags = Access(cur.decode_uint32le())
+
 
 # Alignment Requirement flags
 class Alignment(core.ValueEnum):
@@ -2443,6 +2553,7 @@ class Alignment(core.ValueEnum):
 
 Alignment.import_items(globals())
 
+
 class FileAlignmentInformation(FileInformation):
     file_information_class = FILE_ALIGNMENT_INFORMATION
 
@@ -2452,6 +2563,7 @@ class FileAlignmentInformation(FileInformation):
 
     def _decode(self, cur):
         self.alignment_requirement = Alignment(cur.decode_uint32le())
+
 
 class FileAllInformation(FileInformation):
     file_information_class = FILE_ALL_INFORMATION
@@ -2474,6 +2586,7 @@ class FileAllInformation(FileInformation):
             frame = getattr(self, field)
             if isinstance(frame, core.Frame):
                 frame.decode(cur)
+
 
 class FileDirectoryInformation(FileInformation):
     file_information_class = FILE_DIRECTORY_INFORMATION
@@ -2544,6 +2657,7 @@ class FileFullDirectoryInformation(FileInformation):
             cur.advanceto(self.start + next_offset)
         else:
             cur.advanceto(cur.upperbound)
+
 
 class FileIdFullDirectoryInformation(FileInformation):
     file_information_class = FILE_ID_FULL_DIR_INFORMATION
@@ -2721,6 +2835,7 @@ class CompressionFormat(core.ValueEnum):
     COMPRESSION_FORMAT_NONE = 0x0000
     COMPRESSION_FORMAT_LZNT1 = 0x0002
 
+
 CompressionFormat.import_items(globals())
 
 
@@ -2746,6 +2861,7 @@ class FileCompressionInformation(FileInformation):
         # This is a single reserved field of 3 bytes.
         self.reserved = cur.decode_uint8le() | (cur.decode_uint8le() << 8) | (cur.decode_uint8le() << 16)
 
+
 class FileInternalInformation(FileInformation):
     file_information_class = FILE_INTERNAL_INFORMATION
 
@@ -2755,6 +2871,7 @@ class FileInternalInformation(FileInformation):
 
     def _decode(self, cur):
         self.index_number = cur.decode_uint64le()
+
 
 class FileModeInformation(FileInformation):
     file_information_class = FILE_MODE_INFORMATION
@@ -2770,6 +2887,7 @@ class FileModeInformation(FileInformation):
     def _encode(self, cur):
         cur.encode_uint32le(self.mode)
 
+
 class FileNameInformation(FileInformation):
     file_information_class = FILE_NAME_INFORMATION
 
@@ -2780,6 +2898,7 @@ class FileNameInformation(FileInformation):
     def _decode(self, cur):
         file_name_length = cur.decode_uint32le()
         self.file_name = cur.decode_utf16le(file_name_length)
+
 
 class FileRenameInformation(FileInformation):
     file_information_class = FILE_RENAME_INFORMATION
@@ -2845,6 +2964,7 @@ class FileValidDataLengthInformation(FileInformation):
    def _encode(self, cur):
         cur.encode_int64le(self.valid_data_length)
 
+
 class FileNamesInformation(FileInformation):
     file_information_class = FILE_NAMES_INFORMATION
 
@@ -2906,6 +3026,7 @@ class FileStandardInformation(FileInformation):
         cur.encode_uint8le(self.directory)
         # Ignore 2-bytes Reserved field
         cur.encode_uint16le(0)
+
 
 class FileEaInformation(FileInformation):
     file_information_class = FILE_EA_INFORMATION
@@ -3118,6 +3239,7 @@ class FileFsObjectIdInformation(FileSystemInformation):
         for count in range(6):
             self.extended_info += str(cur.decode_uint64le())
 
+
 class CompletionFilter(core.FlagEnum):
     SMB2_NOTIFY_CHANGE_FILE_NAME    = 0x001
     SMB2_NOTIFY_CHANGE_DIR_NAME     = 0x002
@@ -3132,12 +3254,16 @@ class CompletionFilter(core.FlagEnum):
     SMB2_NOTIFY_CHANGE_STREAM_SIZE  = 0x400
     SMB2_NOTIFY_CHANGE_STREAM_WRITE = 0x800
 
+
 CompletionFilter.import_items(globals())
+
 
 class ChangeNotifyFlags(core.FlagEnum):
     SMB2_WATCH_TREE     = 0x01
 
+
 ChangeNotifyFlags.import_items(globals())
+
 
 class FileNotifyInfoAction(core.ValueEnum):
     SMB2_ACTION_ADDED               = 0x001
@@ -3150,7 +3276,9 @@ class FileNotifyInfoAction(core.ValueEnum):
     SMB2_ACTION_MODIFIED_STREAM     = 0x008
     SMB2_ACTION_REMOVED_BY_DELETE   = 0x009
 
+
 FileNotifyInfoAction.import_items(globals())
+
 
 class FileNotifyInformation(core.Frame):
     def __init__(self, parent = None):
@@ -3173,6 +3301,7 @@ class FileNotifyInformation(core.Frame):
         return "<{0} {1} '{2}'>".format(self.__class__.__name__,
                                         self.action,
                                         self.filename)
+
 
 class ChangeNotifyResponse(Response):
     command_id = SMB2_CHANGE_NOTIFY
@@ -3199,6 +3328,7 @@ class ChangeNotifyResponse(Response):
                 if neo == 0:
                     break
 
+
 class ChangeNotifyRequest(Request):
     command_id = SMB2_CHANGE_NOTIFY
     structure_size = 32
@@ -3219,11 +3349,14 @@ class ChangeNotifyRequest(Request):
         # Reserved
         cur.encode_uint32le(0)
 
+
 class BreakLeaseFlags(core.FlagEnum):
     SMB2_NOTIFY_BREAK_LEASE_FLAG_NONE         = 0x00
     SMB2_NOTIFY_BREAK_LEASE_FLAG_ACK_REQUIRED = 0x01
 
+
 BreakLeaseFlags.import_items(globals())
+
 
 class OplockBreakNotification(Notification):
     command_id = SMB2_OPLOCK_BREAK
@@ -3239,6 +3372,7 @@ class OplockBreakNotification(Notification):
         self.reserved1 = cur.decode_uint8le()
         self.reserved2 = cur.decode_uint32le()
         self.file_id = (cur.decode_uint64le(), cur.decode_uint64le())
+
 
 class LeaseBreakNotification(Notification):
     command_id = SMB2_OPLOCK_BREAK
@@ -3262,6 +3396,7 @@ class LeaseBreakNotification(Notification):
         self.access_mask_hint = cur.decode_uint32le()
         self.share_mask_hint = cur.decode_uint32le()
 
+
 class OplockBreakAcknowledgement(Request):
     command_id = SMB2_OPLOCK_BREAK
     structure_size = 24
@@ -3279,6 +3414,7 @@ class OplockBreakAcknowledgement(Request):
         cur.encode_uint32le(0)
         cur.encode_uint64le(self.file_id[0])
         cur.encode_uint64le(self.file_id[1])
+
 
 class LeaseBreakAcknowledgement(Request):
     command_id = SMB2_OPLOCK_BREAK
@@ -3299,6 +3435,7 @@ class LeaseBreakAcknowledgement(Request):
         # LeaseDuration is reserved
         cur.encode_uint64le(0)
 
+
 class OplockBreakResponse(Response):
     command_id = SMB2_OPLOCK_BREAK
     structure_size = 24
@@ -3313,6 +3450,7 @@ class OplockBreakResponse(Response):
         self.reserved1 = cur.decode_uint8le()
         self.reserved2 = cur.decode_uint32le()
         self.file_id = (cur.decode_uint64le(), cur.decode_uint64le())
+
 
 class LeaseBreakResponse(Response):
     command_id = SMB2_OPLOCK_BREAK
@@ -3330,6 +3468,7 @@ class LeaseBreakResponse(Response):
         self.lease_key = cur.decode_bytes(16)
         self.lease_state = LeaseState(cur.decode_uint32le())
         self.lease_duration = cur.decode_uint64le()
+
 
 class ReadRequest(Request):
     command_id = SMB2_READ
@@ -3416,11 +3555,14 @@ class ReadResponse(Response):
 
         self.data = cur.decode_bytes(self.length)
 
+
 # Flag constants
 class WriteFlags(core.FlagEnum):
     SMB2_WRITEFLAG_WRITE_THROUGH = 0x00000001
 
+
 WriteFlags.import_items(globals())
+
 
 class WriteRequest(Request):
     command_id = SMB2_WRITE
@@ -3478,6 +3620,7 @@ class WriteRequest(Request):
         if self.buffer:
             cur.encode_bytes(self.buffer)
 
+
 class WriteResponse(Response):
     command_id = SMB2_WRITE
     structure_size = 17
@@ -3506,13 +3649,16 @@ class WriteResponse(Response):
         self.write_channel_info_offset = cur.decode_uint16le()
         self.write_channel_info_length = cur.decode_uint16le()
 
+
 class LockFlags(core.FlagEnum):
     SMB2_LOCKFLAG_SHARED_LOCK      = 0x00000001
     SMB2_LOCKFLAG_EXCLUSIVE_LOCK   = 0x00000002
     SMB2_LOCKFLAG_UN_LOCK          = 0x00000004
     SMB2_LOCKFLAG_FAIL_IMMEDIATELY = 0x00000010
 
+
 LockFlags.import_items(globals())
+
 
 class LockRequest(Request):
     """
@@ -3546,6 +3692,7 @@ class LockRequest(Request):
             # Reserved
             cur.encode_uint32le(0)
 
+
 class LockResponse(Response):
     command_id = SMB2_LOCK
     structure_size = 4
@@ -3555,6 +3702,7 @@ class LockResponse(Response):
 
     def _decode(self, cur):
         self.reserved = cur.decode_uint16le()
+
 
 class IoctlCode(core.ValueEnum):
     FSCTL_DFS_GET_REFERRALS            = 0x00060194
@@ -3576,12 +3724,16 @@ class IoctlCode(core.ValueEnum):
     FSCTL_SET_ZERO_DATA                = 0x000980C8
     FSCTL_SET_SPARSE                   = 0x000900C4
 
+
 IoctlCode.import_items(globals())
+
 
 class IoctlFlags(core.FlagEnum):
     SMB2_0_IOCTL_IS_FSCTL = 0x00000001
 
+
 IoctlFlags.import_items(globals())
+
 
 class IoctlRequest(Request):
     command_id = SMB2_IOCTL
@@ -3639,6 +3791,7 @@ class IoctlRequest(Request):
         # Set the ioctl count, which is the length in bytes
         input_count_hole(cur - buffer_start)
 
+
 class IoctlResponse(Response):
     command_id = SMB2_IOCTL
     structure_size = 49
@@ -3677,11 +3830,13 @@ class IoctlResponse(Response):
         with cur.bounded(cur, end):
             ioctl(self).decode(cur)
 
+
 class IoctlInput(core.Frame):
     def __init__(self, parent):
         super(IoctlInput, self).__init__(parent)
         if parent is not None:
             parent.ioctl_input = self
+
 
 class ValidateNegotiateInfoRequest(IoctlInput):
     ioctl_ctl_code = FSCTL_VALIDATE_NEGOTIATE_INFO
@@ -3707,6 +3862,7 @@ class ValidateNegotiateInfoRequest(IoctlInput):
         for dialect in self.dialects:
             cur.encode_uint16le(dialect)
 
+
 class QueryNetworkInterfaceInfoRequest(IoctlInput):
     ioctl_ctl_code = FSCTL_QUERY_NETWORK_INTERFACE_INFO
 
@@ -3715,6 +3871,7 @@ class QueryNetworkInterfaceInfoRequest(IoctlInput):
 
     def  _encode(self, cur):
         pass
+
 
 class RequestResumeKeyRequest(IoctlInput):
     ioctl_ctl_code = FSCTL_SRV_REQUEST_RESUME_KEY
@@ -3725,6 +3882,7 @@ class RequestResumeKeyRequest(IoctlInput):
 
     def  _encode(self, cur):
         pass
+
 
 class NetworkResiliencyRequestRequest(IoctlInput):
     ioctl_ctl_code = FSCTL_LMR_REQUEST_RESILIENCY
@@ -3737,6 +3895,7 @@ class NetworkResiliencyRequestRequest(IoctlInput):
     def  _encode(self, cur):
         cur.encode_uint32le(self.timeout)
         cur.encode_uint32le(self.reserved)
+
 
 class CopyChunkCopyRequest(IoctlInput):
     ioctl_ctl_code = FSCTL_SRV_COPYCHUNK
@@ -3758,8 +3917,10 @@ class CopyChunkCopyRequest(IoctlInput):
         for chunk in self._children:
             chunk.encode(cur)
 
+
 class CopyChunkCopyWriteRequest(CopyChunkCopyRequest):
     ioctl_ctl_code = FSCTL_SRV_COPYCHUNK_WRITE
+
 
 class CopyChunk(core.Frame):
     def __init__(self, parent):
@@ -3775,6 +3936,7 @@ class CopyChunk(core.Frame):
         cur.encode_uint32le(self.length)
         cur.encode_uint32le(0)
 
+
 class SetReparsePointRequest(IoctlInput):
     ioctl_ctl_code = FSCTL_SET_REPARSE_POINT
 
@@ -3785,6 +3947,7 @@ class SetReparsePointRequest(IoctlInput):
     def _encode(self, cur):
         if self.reparse_data is not None:
             self.reparse_data.encode(cur)
+
 
 class GetReparsePointRequest(IoctlInput):
     ioctl_ctl_code = FSCTL_GET_REPARSE_POINT
@@ -3798,12 +3961,14 @@ class EnumerateSnapshotsRequest(IoctlInput):
     def _encode(self, *args, **kwds):
         pass
 
+
 @IoctlResponse.ioctl_ctl_code
 class IoctlOutput(core.Frame):
     def __init__(self, parent):
         super(IoctlOutput, self).__init__(parent)
         if parent is not None:
             parent.ioctl_output = self
+
 
 class ValidateNegotiateInfoResponse(IoctlOutput):
     ioctl_ctl_code = FSCTL_VALIDATE_NEGOTIATE_INFO
@@ -3821,6 +3986,7 @@ class ValidateNegotiateInfoResponse(IoctlOutput):
         self.security_mode = SecurityMode(cur.decode_uint16le())
         self.dialect = Dialect(cur.decode_uint16le())
 
+
 class QueryNetworkInterfaceInfoResponse(IoctlOutput):
     ioctl_ctl_code = FSCTL_QUERY_NETWORK_INTERFACE_INFO
 
@@ -3829,6 +3995,7 @@ class QueryNetworkInterfaceInfoResponse(IoctlOutput):
 
     def _decode(self, cur):
         pass
+
 
 class RequestResumeKeyResponse(IoctlOutput):
    ioctl_ctl_code = FSCTL_SRV_REQUEST_RESUME_KEY
@@ -3842,12 +4009,14 @@ class RequestResumeKeyResponse(IoctlOutput):
         self.resume_key = cur.decode_bytes(24)
         self.context_length = cur.decode_uint32le()
 
+
 class NetworkResiliencyRequestResponse(IoctlOutput):
 
     ioctl_ctl_code = FSCTL_LMR_REQUEST_RESILIENCY
 
     def _decode(self, cur):
         pass
+
 
 class CopyChunkCopyResponse(IoctlOutput):
    ioctl_ctl_code = FSCTL_SRV_COPYCHUNK
@@ -3863,13 +4032,16 @@ class CopyChunkCopyResponse(IoctlOutput):
         self.chunk_bytes_written = cur.decode_uint32le()
         self.total_bytes_written = cur.decode_uint32le()
 
+
 class CopyChunkCopyWriteResponse(CopyChunkCopyResponse):
     ioctl_ctl_code = FSCTL_SRV_COPYCHUNK_WRITE
+
 
 class SetReparsePointResponse(IoctlOutput):
     ioctl_ctl_code = FSCTL_SET_REPARSE_POINT
     def _decode(self, *args, **kwds):
         pass
+
 
 class GetReparsePointResponse(IoctlOutput):
     ioctl_ctl_code = FSCTL_GET_REPARSE_POINT
@@ -3890,6 +4062,7 @@ class GetReparsePointResponse(IoctlOutput):
         reparse_data = self._reparse_tag_map[self.tag]
         reparse_data(self).decode(cur)
 
+
 @GetReparsePointResponse.reparse_tag
 class ReparseDataBuffer(core.Frame):
     def __init__(self, parent):
@@ -3897,10 +4070,14 @@ class ReparseDataBuffer(core.Frame):
         if parent is not None:
             parent.reparse_data = self
 
+
 class SymbolicLinkFlags(core.FlagEnum):
     SYMLINK_FLAG_ABSOLUTE = 0x0
     SYMLINK_FLAG_RELATIVE = 0x1
+
+
 SymbolicLinkFlags.import_items(globals())
+
 
 class SymbolicLinkReparseBuffer(ReparseDataBuffer):
     reparse_tag = 0xA000000C
@@ -3960,6 +4137,7 @@ class SymbolicLinkReparseBuffer(ReparseDataBuffer):
         cur.seekto(buf_start + self.print_name_offset)
         self.print_name = cur.decode_utf16le(self.print_name_length)
 
+
 class EnumerateSnapshotsResponse(IoctlOutput):
     ioctl_ctl_code = FSCTL_SRV_ENUMERATE_SNAPSHOTS
 
@@ -3977,6 +4155,7 @@ class EnumerateSnapshotsResponse(IoctlOutput):
         snapshot_buffer = cur.decode_utf16le(self.snapshot_array_size)
         # TODO: handle the case where the buffer is too small
         self.snapshots = snapshot_buffer.strip("\0").split("\0")
+
 
 class SetZeroDataRequest(IoctlInput):
     ioctl_ctl_code = IoctlCode.FSCTL_SET_ZERO_DATA
@@ -4001,6 +4180,7 @@ class SetZeroDataResponse(IoctlOutput):
 
     def _decode(self, cur):
         pass
+
 
 class SetSparseRequest(IoctlInput):
     ioctl_ctl_code = IoctlCode.FSCTL_SET_SPARSE

--- a/pike/smb2.py
+++ b/pike/smb2.py
@@ -1,27 +1,7 @@
 #
-# Copyright (c) 2013, EMC Corporation
+# Copyright (c) 2013-2020, Dell Inc. or its subsidiaries.
 # All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice,
-# this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# See file LICENSE for licensing information.
 #
 # Module Name:
 #

--- a/pike/test/__init__.py
+++ b/pike/test/__init__.py
@@ -1,27 +1,7 @@
 #
-# Copyright (c) 2013, EMC Corporation
+# Copyright (c) 2020, Dell Inc. or its subsidiaries.
 # All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice,
-# this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# See file LICENSE for licensing information.
 #
 # Module Name:
 #
@@ -33,6 +13,7 @@
 #
 # Authors: Brian Koropoff (brian.koropoff@emc.com)
 #
+
 from __future__ import print_function
 from __future__ import division
 from builtins import object

--- a/pike/test/acl.py
+++ b/pike/test/acl.py
@@ -1,27 +1,7 @@
 #
-# Copyright (c) 2013, EMC Corporation
+# Copyright (c) 2020, Dell Inc. or its subsidiaries.
 # All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice,
-# this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# See file LICENSE for licensing information.
 #
 # Module Name:
 #
@@ -32,6 +12,7 @@
 #        SMB2/3 ACL set/get testing.
 #
 #
+
 import pike.model
 import pike.smb2
 import pike.test

--- a/pike/test/appinstanceid.py
+++ b/pike/test/appinstanceid.py
@@ -1,27 +1,7 @@
 #
-# Copyright (c) 2013, EMC Corporation
+# Copyright (c) 2013-2020, Dell Inc. or its subsidiaries.
 # All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice,
-# this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# See file LICENSE for licensing information.
 #
 # Module Name:
 #

--- a/pike/test/appinstanceid.py
+++ b/pike/test/appinstanceid.py
@@ -22,6 +22,7 @@ import pike.ntstatus
 import random
 import array
 
+
 @pike.test.RequireDialect(pike.smb2.DIALECT_SMB3_0)
 @pike.test.RequireCapabilities(pike.smb2.SMB2_GLOBAL_CAP_PERSISTENT_HANDLES)
 @pike.test.RequireShareCapabilities(pike.smb2.SMB2_SHARE_CAP_CONTINUOUS_AVAILABILITY)

--- a/pike/test/changenotify.py
+++ b/pike/test/changenotify.py
@@ -19,6 +19,7 @@ import pike.ntstatus
 import pike.smb2
 import pike.test
 
+
 class ChangeNotifyTest(pike.test.PikeTest):
     def test_change_notify_file_name(self):
         filename = "change_notify.txt"

--- a/pike/test/changenotify.py
+++ b/pike/test/changenotify.py
@@ -1,27 +1,7 @@
 #
-# Copyright (c) 2013, EMC Corporation
+# Copyright (c) 2013-2020, Dell Inc. or its subsidiaries.
 # All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice,
-# this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# See file LICENSE for licensing information.
 #
 # Module Name:
 #

--- a/pike/test/compound.py
+++ b/pike/test/compound.py
@@ -1,27 +1,7 @@
 #
-# Copyright (c) 2013, EMC Corporation
+# Copyright (c) 2013-2020, Dell Inc. or its subsidiaries.
 # All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice,
-# this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# See file LICENSE for licensing information.
 #
 # Module Name:
 #

--- a/pike/test/copychunk.py
+++ b/pike/test/copychunk.py
@@ -42,11 +42,13 @@ SIMPLE_5_CHUNKS = [(0, 0, 4000), (4000, 4000, 4000), (8000, 8000, 4000),
                    (12000, 12000, 4000), (16000, 16000, 4000)]
 SIMPLE_5_CHUNKS_LEN = 20000
 
+
 def _gen_test_buffer(length):
     # XXX: refactor and push up into helper/util module
     pattern = "".join([chr(x) for x in range(ord(' '), ord('~'))])
     buf = (pattern * ((length // len(pattern)) + 1))[:length]
     return buf.encode("ascii")
+
 
 def _gen_random_test_buffer(length):
     # XXX: refactor and push up into helper/util module
@@ -63,6 +65,7 @@ def _gen_random_test_buffer(length):
 ###
 # Main test
 ###
+
 class TestServerSideCopy(pike.test.PikeTest):
     # these values are valid for Windows -- other servers may need to adjust
     bad_resume_key_error = pike.ntstatus.STATUS_OBJECT_NAME_NOT_FOUND

--- a/pike/test/copychunk.py
+++ b/pike/test/copychunk.py
@@ -1,27 +1,7 @@
 #
-# Copyright (c) 2015, EMC Corporation
+# Copyright (c) 2015-2020, Dell Inc. or its subsidiaries.
 # All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice,
-# this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# See file LICENSE for licensing information.
 #
 # Module Name:
 #
@@ -34,6 +14,7 @@
 # Authors: Avi Bhandari (avi.bahndari@emc.com)
 #          Masen Furer (masen.furer@emc.com)
 #
+
 from __future__ import division
 from builtins import chr
 from builtins import range

--- a/pike/test/credit.py
+++ b/pike/test/credit.py
@@ -1,27 +1,7 @@
 #
-# Copyright (c) 2017, Dell EMC Corporation
+# Copyright (c) 2017-2020, Dell Inc. or its subsidiaries.
 # All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice,
-# this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# See file LICENSE for licensing information.
 #
 # Module Name:
 #
@@ -33,6 +13,7 @@
 #
 # Authors: Masen Furer <masen.furer@dell.com>
 #
+
 from __future__ import division
 from __future__ import print_function
 from builtins import map

--- a/pike/test/credit.py
+++ b/pike/test/credit.py
@@ -42,6 +42,7 @@ size_8m = 2**23
 share_all = pike.smb2.FILE_SHARE_READ | pike.smb2.FILE_SHARE_WRITE | pike.smb2.FILE_SHARE_DELETE
 lease_rh = pike.smb2.SMB2_LEASE_READ_CACHING | pike.smb2.SMB2_LEASE_HANDLE_CACHING
 
+
 # debugging callback functions which are registered if debug logging is enabled
 def post_serialize_credit_assessment(nb):
     smb_res = nb[0]
@@ -52,6 +53,7 @@ def post_serialize_credit_assessment(nb):
         smb_res.credit_request,
         nb.conn.credits))
 
+
 def post_deserialize_credit_assessment(nb):
     smb_res = nb[0]
     print("{0} ({1}) ___ Charge: {2} / Response: {3} / Total: {4}".format(
@@ -60,6 +62,7 @@ def post_deserialize_credit_assessment(nb):
         smb_res.credit_charge,
         smb_res.credit_response,
         nb.conn.credits + smb_res.credit_response - smb_res.credit_charge))
+
 
 def post_serialize_credit_assert(exp_credit_charge, future):
     def cb(nb):
@@ -71,6 +74,7 @@ def post_serialize_credit_assert(exp_credit_charge, future):
                                 nb[0].credit_charge))
             future.complete(True)
     return cb
+
 
 @pike.test.RequireCapabilities(pike.smb2.SMB2_GLOBAL_CAP_LARGE_MTU)
 class CreditTest(pike.test.PikeTest):
@@ -331,6 +335,7 @@ class CreditTest(pike.test.PikeTest):
         chan.close(fh)
         self.assertEqual(read_buffer.tobytes(), file_buf)
 
+
 class PowerOf2CreditTest(CreditTest):
 
     def test_1_1m_write_1_1m_read(self):
@@ -356,6 +361,7 @@ class PowerOf2CreditTest(CreditTest):
 
     def test_5_192k_write_1_960k_read(self):
         self.generic_mc_write_mc_read(size_960k, size_192k, size_960k)
+
 
 class EdgeCreditTest(CreditTest):
     def test_sequence_number_wrap(self):
@@ -401,6 +407,7 @@ class EdgeCreditTest(CreditTest):
 
         # at the end, next mid should be > target
         self.assertGreater(chan1.connection._next_mid, sequence_number_target)
+
 
 class AsyncCreditTest(CreditTest):
     def test_async_lock(self):
@@ -522,6 +529,7 @@ class AsyncCreditTest(CreditTest):
         chan2.close(fh2)
         chan1.close(fh1)
 
+
 class TestCaseGenerator(object):
     header = """#!/usr/bin/env python
 import pike.test
@@ -536,6 +544,7 @@ class Generated_{name}_{tag}(pike.test.credit.CreditTest):
     template = """
     def test_{name}_{tag}_{ix}(self):
         self.generic_arbitrary_mc_write_mc_read({file_size}, {write_size}, {read_size})"""
+
     @classmethod
     def generate_multiple_64k_test_cases(cls, tag, n_cases, size_range_multiple, write_range_multiple, read_range_multiple):
         name = "Mult64k"
@@ -557,6 +566,7 @@ class Generated_{name}_{tag}(pike.test.credit.CreditTest):
             read_size = random.randint(*read_range)
             print(cls.template.format(**locals()))
         print(cls.footer.format(**locals()))
+
 
 if __name__ == "__main__":
     import argparse

--- a/pike/test/durable.py
+++ b/pike/test/durable.py
@@ -1,27 +1,7 @@
 #
-# Copyright (c) 2013, EMC Corporation
+# Copyright (c) 2013-2020, Dell Inc. or its subsidiaries.
 # All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice,
-# this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# See file LICENSE for licensing information.
 #
 # Module Name:
 #
@@ -33,6 +13,7 @@
 #
 # Authors: Arlene Berry (arlene.berry@emc.com)
 #
+
 from builtins import map
 
 import array

--- a/pike/test/durable.py
+++ b/pike/test/durable.py
@@ -25,6 +25,7 @@ import pike.smb2
 import pike.test
 import pike.ntstatus
 
+
 # for buffer too small
 class InvalidNetworkResiliencyRequestRequest(pike.smb2.NetworkResiliencyRequestRequest):
     def  _encode(self, cur):

--- a/pike/test/echo.py
+++ b/pike/test/echo.py
@@ -1,27 +1,7 @@
 #
-# Copyright (c) 2013, EMC Corporation
+# Copyright (c) 2013-2020, Dell Inc. or its subsidiaries.
 # All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice,
-# this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# See file LICENSE for licensing information.
 #
 # Module Name:
 #
@@ -33,6 +13,7 @@
 #
 # Authors: Angela Bartholomaus (angela.bartholomaus@emc.com)
 #
+
 import pike.test
 
 

--- a/pike/test/encryption.py
+++ b/pike/test/encryption.py
@@ -1,27 +1,7 @@
 #
-# Copyright (c) 2016, EMC Corporation
+# Copyright (c) 2016-2020, Dell Inc. or its subsidiaries.
 # All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice,
-# this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# See file LICENSE for licensing information.
 #
 # Module Name:
 #

--- a/pike/test/encryption.py
+++ b/pike/test/encryption.py
@@ -19,6 +19,7 @@ import pike.model as model
 import pike.smb2 as smb2
 import pike.test
 
+
 class TestEncryption(pike.test.PikeTest):
     def test_smb_3_0_encryption(self):
         client = model.Client(dialects=[smb2.DIALECT_SMB3_0])
@@ -124,6 +125,7 @@ class TestEncryption(pike.test.PikeTest):
         self.assertIsNotNone(parent.transform)
         for r in resp:
             self.assertEqual(r.parent, parent)
+
 
 if __name__ == "__main__":
     pike.test.unittest.main()

--- a/pike/test/internal/test_callbacks.py
+++ b/pike/test/internal/test_callbacks.py
@@ -9,6 +9,7 @@ import pike.model as model
 import pike.smb2 as smb2
 import pike.test
 
+
 class TestClientCallbacks(pike.test.PikeTest):
     def test_pre_serialize(self):
         callback_future = model.Future()
@@ -108,6 +109,7 @@ class TestClientCallbacks(pike.test.PikeTest):
         conn.negotiate()
         self.assertTrue(pre_callback_future.result(timeout=2))
         self.assertTrue(post_callback_future.result(timeout=2))
+
 
 class TestConnectionCallbacks(pike.test.PikeTest):
     def test_pre_serialize(self):

--- a/pike/test/internal/test_callbacks.py
+++ b/pike/test/internal/test_callbacks.py
@@ -1,3 +1,9 @@
+#
+# Copyright (c) 2020, Dell Inc. or its subsidiaries.
+# All rights reserved.
+# See file LICENSE for licensing information.
+#
+
 import pike.core as core
 import pike.model as model
 import pike.smb2 as smb2

--- a/pike/test/internal/test_client.py
+++ b/pike/test/internal/test_client.py
@@ -1,3 +1,9 @@
+#
+# Copyright (c) 2020, Dell Inc. or its subsidiaries.
+# All rights reserved.
+# See file LICENSE for licensing information.
+#
+
 import pytest
 
 from pike.model import Client

--- a/pike/test/internal/test_write.py
+++ b/pike/test/internal/test_write.py
@@ -1,3 +1,9 @@
+#
+# Copyright (c) 2020, Dell Inc. or its subsidiaries.
+# All rights reserved.
+# See file LICENSE for licensing information.
+#
+
 from __future__ import unicode_literals
 from builtins import str
 

--- a/pike/test/invalid_session.py
+++ b/pike/test/invalid_session.py
@@ -1,27 +1,7 @@
 #
-# Copyright (c) 2017, Dell EMC Corporation
+# Copyright (c) 2017-2020, Dell Inc. or its subsidiaries.
 # All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice,
-# this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# See file LICENSE for licensing information.
 #
 # Module Name:
 #
@@ -33,7 +13,6 @@
 #
 # Authors: Rafal Szczesniak (rafal.szczesniak@isilon.com)
 #
-
 
 import pike.model
 import pike.ntstatus as nt

--- a/pike/test/invalid_session.py
+++ b/pike/test/invalid_session.py
@@ -43,7 +43,6 @@ class InvalidSessionTest(pike.test.PikeTest):
             disposition=smb2.FILE_SUPERSEDE).result()
         return fh
 
-
     def test_treeconnect(self):
         chan, tree = self.tree_connect()
 
@@ -59,7 +58,6 @@ class InvalidSessionTest(pike.test.PikeTest):
             chan.connection.transceive(req1.parent)[0]
 
         chan.connection.close()
-
 
     def test_ioctl(self):
         fh = self.open_file("test.txt")
@@ -83,7 +81,6 @@ class InvalidSessionTest(pike.test.PikeTest):
             self.chan.connection.transceive(req1.parent)
 
         self.chan.connection.close()
-
 
     def test_oplock_break_ack(self):
         fh = self.open_file("test.txt")

--- a/pike/test/invalid_tree.py
+++ b/pike/test/invalid_tree.py
@@ -1,27 +1,7 @@
 #
-# Copyright (c) 2017, Dell EMC Corporation
+# Copyright (c) 2017-2020, Dell Inc. or its subsidiaries.
 # All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice,
-# this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# See file LICENSE for licensing information.
 #
 # Module Name:
 #
@@ -33,7 +13,6 @@
 #
 # Authors: Rafal Szczesniak (rafal.szczesniak@isilon.com)
 #
-
 
 import pike.model
 import pike.ntstatus as nt

--- a/pike/test/invalid_tree.py
+++ b/pike/test/invalid_tree.py
@@ -19,6 +19,7 @@ import pike.ntstatus as nt
 import pike.smb2 as smb2
 import pike.test
 
+
 class InvalidTreeTest(pike.test.PikeTest):
     def open_file(self, filename):
         self.chan, self.tree = self.tree_connect()
@@ -27,7 +28,6 @@ class InvalidTreeTest(pike.test.PikeTest):
             filename,
             disposition=smb2.FILE_SUPERSEDE).result()
         return fh
-
 
     def test_treeconnect(self):
         chan, tree = self.tree_connect()
@@ -58,7 +58,6 @@ class InvalidTreeTest(pike.test.PikeTest):
 
         chan.connection.close()
 
-
     def test_ioctl(self):
         fh = self.open_file("test.txt")
 
@@ -81,7 +80,6 @@ class InvalidTreeTest(pike.test.PikeTest):
             self.chan.connection.transceive(req1.parent)
 
         self.chan.connection.close()
-
 
     def test_oplock_break_ack(self):
         fh = self.open_file("test.txt")

--- a/pike/test/ioctl.py
+++ b/pike/test/ioctl.py
@@ -1,27 +1,7 @@
 #
-# Copyright (c) 2013, EMC Corporation
+# Copyright (c) 2013-2020, Dell Inc. or its subsidiaries.
 # All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice,
-# this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# See file LICENSE for licensing information.
 #
 # Module Name:
 #

--- a/pike/test/lease.py
+++ b/pike/test/lease.py
@@ -1,27 +1,7 @@
 #
-# Copyright (c) 2013, EMC Corporation
+# Copyright (c) 2013-2020, Dell Inc. or its subsidiaries.
 # All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice,
-# this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# See file LICENSE for licensing information.
 #
 # Module Name:
 #
@@ -33,6 +13,7 @@
 #
 # Authors: Brian Koropoff (brian.koropoff@emc.com)
 #
+
 from builtins import map
 
 import array

--- a/pike/test/lease.py
+++ b/pike/test/lease.py
@@ -23,6 +23,7 @@ import pike.model
 import pike.smb2
 import pike.test
 
+
 @pike.test.RequireDialect(0x210)
 @pike.test.RequireCapabilities(pike.smb2.SMB2_GLOBAL_CAP_LEASING)
 class LeaseTest(pike.test.PikeTest):

--- a/pike/test/lock.py
+++ b/pike/test/lock.py
@@ -1,27 +1,7 @@
 #
-# Copyright (c) 2013, EMC Corporation
+# Copyright (c) 2013-2020, Dell Inc. or its subsidiaries.
 # All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice,
-# this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# See file LICENSE for licensing information.
 #
 # Module Name:
 #

--- a/pike/test/lock.py
+++ b/pike/test/lock.py
@@ -20,6 +20,7 @@ import pike.smb2
 import pike.test
 import pike.ntstatus
 
+
 class LockTest(pike.test.PikeTest):
     # Take a basic byte-range lock
     def test_lock(self):
@@ -162,8 +163,10 @@ class LockTest(pike.test.PikeTest):
         chan.close(file1)
         chan.close(file2)
 
+
 def range_contains(a1, a2, b):
     return b >= a1 and b < a2
+
 
 def ranges_intersect(a1, a2, b1, b2):
     return a2 > a1 and b2 > b1 and \

--- a/pike/test/multichannel.py
+++ b/pike/test/multichannel.py
@@ -1,27 +1,7 @@
 #
-# Copyright (c) 2013, EMC Corporation
+# Copyright (c) 2013-2020, Dell Inc. or its subsidiaries.
 # All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice,
-# this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# See file LICENSE for licensing information.
 #
 # Module Name:
 #

--- a/pike/test/multichannel.py
+++ b/pike/test/multichannel.py
@@ -19,6 +19,7 @@ import pike.smb2
 import pike.test
 import pike.ntstatus
 
+
 @pike.test.RequireDialect(pike.smb2.DIALECT_SMB3_0)
 @pike.test.RequireCapabilities(pike.smb2.SMB2_GLOBAL_CAP_MULTI_CHANNEL)
 class MultiChannelTest(pike.test.PikeTest):

--- a/pike/test/negotiate.py
+++ b/pike/test/negotiate.py
@@ -1,27 +1,7 @@
 #
-# Copyright (c) 2013, EMC Corporation
+# Copyright (c) 2013-2020, Dell Inc. or its subsidiaries.
 # All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice,
-# this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# See file LICENSE for licensing information.
 #
 # Module Name:
 #

--- a/pike/test/negotiate.py
+++ b/pike/test/negotiate.py
@@ -20,6 +20,7 @@ import pike.crypto as crypto
 import pike.smb2 as smb2
 import pike.test as test
 
+
 class CapTest(test.PikeTest):
     def setup(self):
         # determine max capability and apply Required decorators
@@ -61,6 +62,7 @@ class CapTest(test.PikeTest):
         conn = self.negotiate(smb2.DIALECT_SMB2_002, cap)
         self.assertEqual(conn.negotiate_response.capabilities & cap, 0)
 
+
 class CapPersistent(CapTest):
     # persistent cap is advertised if we ask for it
     @test.RequireDialect(smb2.DIALECT_SMB3_0)
@@ -93,6 +95,7 @@ class CapPersistent(CapTest):
     def test_downlevel(self):
         self.downlevel_cap(smb2.SMB2_GLOBAL_CAP_PERSISTENT_HANDLES)
 
+
 class CapMultichannel(CapTest):
     # multichannel cap is advertised if we ask for it
     @test.RequireDialect(smb2.DIALECT_SMB3_0)
@@ -123,6 +126,7 @@ class CapMultichannel(CapTest):
     def test_downlevel(self):
         self.downlevel_cap(smb2.SMB2_GLOBAL_CAP_MULTI_CHANNEL)
 
+
 class CapMulticredit(CapTest):
     # largemtu cap is advertised if we ask for it
     @test.RequireDialect(smb2.DIALECT_SMB3_0)
@@ -148,6 +152,7 @@ class CapMulticredit(CapTest):
     # multicredit cap is not advertised to downlevel client
     def test_downlevel(self):
         self.downlevel_cap(smb2.SMB2_GLOBAL_CAP_LARGE_MTU)
+
 
 @test.RequireDialect(smb2.DIALECT_SMB3_1_1)
 class NegotiateContext(test.PikeTest):

--- a/pike/test/oplock.py
+++ b/pike/test/oplock.py
@@ -1,27 +1,7 @@
 #
-# Copyright (c) 2013, EMC Corporation
+# Copyright (c) 2013-2020, Dell Inc. or its subsidiaries.
 # All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice,
-# this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# See file LICENSE for licensing information.
 #
 # Module Name:
 #

--- a/pike/test/oplock.py
+++ b/pike/test/oplock.py
@@ -18,6 +18,7 @@ import pike.model
 import pike.smb2
 import pike.test
 
+
 class OplockTest(pike.test.PikeTest):
     # Open a handle with an oplock and break it
     def test_oplock_break(self):

--- a/pike/test/persistent.py
+++ b/pike/test/persistent.py
@@ -1,27 +1,7 @@
 #
-# Copyright (c) 2013, EMC Corporation
+# Copyright (c) 2013-2020, Dell Inc. or its subsidiaries.
 # All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice,
-# this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# See file LICENSE for licensing information.
 #
 # Module Name:
 #

--- a/pike/test/persistent.py
+++ b/pike/test/persistent.py
@@ -32,10 +32,12 @@ LEASE_RH  = LEASE_R | smb2.SMB2_LEASE_HANDLE_CACHING
 LEASE_RWH = LEASE_RW | LEASE_RH
 SHARE_ALL = smb2.FILE_SHARE_READ | smb2.FILE_SHARE_WRITE | smb2.FILE_SHARE_DELETE
 
+
 class InvalidNetworkResiliencyRequestRequest(pike.smb2.NetworkResiliencyRequestRequest):
     def  _encode(self, cur):
         cur.encode_uint32le(self.timeout)
         cur.encode_uint16le(self.reserved)
+
 
 @test.RequireDialect(smb2.DIALECT_SMB3_0)
 @test.RequireCapabilities(smb2.SMB2_GLOBAL_CAP_PERSISTENT_HANDLES)
@@ -202,7 +204,6 @@ class Persistent(test.PikeTest):
         # Because resiliency timeout, other opener has broken the persistent, so reconnect would fail
         with self.assert_error(pike.ntstatus.STATUS_OBJECT_NAME_NOT_FOUND):
             handle3 = self.create_persistent(prev_handle=handle1)
-
 
     def test_resiliency_same_timeout_reconnect_after_timeout(self):
         handle1 = self.create_persistent()

--- a/pike/test/query.py
+++ b/pike/test/query.py
@@ -1,27 +1,7 @@
 #
-# Copyright (c) 2013, EMC Corporation
+# Copyright (c) 2013-2020, Dell Inc. or its subsidiaries.
 # All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice,
-# this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# See file LICENSE for licensing information.
 #
 # Module Name:
 #

--- a/pike/test/querydirectory.py
+++ b/pike/test/querydirectory.py
@@ -1,27 +1,7 @@
 #
-# Copyright (c) 2013, EMC Corporation
+# Copyright (c) 2013-2020, Dell Inc. or its subsidiaries.
 # All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice,
-# this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# See file LICENSE for licensing information.
 #
 # Module Name:
 #

--- a/pike/test/queryondiskid.py
+++ b/pike/test/queryondiskid.py
@@ -1,27 +1,7 @@
 #
-# Copyright (c) 2013, EMC Corporation
+# Copyright (c) 2013-2020, Dell Inc. or its subsidiaries.
 # All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice,
-# this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# See file LICENSE for licensing information.
 #
 # Module Name:
 #

--- a/pike/test/queryondiskid.py
+++ b/pike/test/queryondiskid.py
@@ -28,6 +28,7 @@ access_rwd = pike.smb2.GENERIC_READ | \
              pike.smb2.DELETE
 null_fid = array.array('B', [0]*32)
 
+
 class TestQueryOnDiskID(pike.test.PikeTest):
     test_files = [ "qfid_file.bin", "qfid_same_file.bin",
                    "qfid_diff_file1.bin", "qfid_diff_file2.bin" ]

--- a/pike/test/readwrite.py
+++ b/pike/test/readwrite.py
@@ -24,6 +24,7 @@ import pike.smb2
 import pike.test
 import pike.ntstatus
 
+
 class ReadWriteTest(pike.test.PikeTest):
     # Test that we can write to a file
     def test_write(self):

--- a/pike/test/readwrite.py
+++ b/pike/test/readwrite.py
@@ -1,27 +1,7 @@
 #
-# Copyright (c) 2013, EMC Corporation
+# Copyright (c) 2013-2020, Dell Inc. or its subsidiaries.
 # All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice,
-# this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# See file LICENSE for licensing information.
 #
 # Module Name:
 #

--- a/pike/test/reparse.py
+++ b/pike/test/reparse.py
@@ -1,27 +1,7 @@
 #
-# Copyright (c) 2013, EMC Corporation
+# Copyright (c) 2013-2020, Dell Inc. or its subsidiaries.
 # All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice,
-# this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# See file LICENSE for licensing information.
 #
 # Module Name:
 #

--- a/pike/test/session.py
+++ b/pike/test/session.py
@@ -1,27 +1,7 @@
 #
-# Copyright (c) 2013, EMC Corporation
+# Copyright (c) 2013-2020, Dell Inc. or its subsidiaries.
 # All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice,
-# this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# See file LICENSE for licensing information.
 #
 # Module Name:
 #

--- a/pike/test/set.py
+++ b/pike/test/set.py
@@ -1,27 +1,7 @@
 #
-# Copyright (c) 2013, EMC Corporation
+# Copyright (c) 2013-2020, Dell Inc. or its subsidiaries.
 # All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice,
-# this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# See file LICENSE for licensing information.
 #
 # Module Name:
 #

--- a/pike/test/test_smb3_encryption_vector.py
+++ b/pike/test/test_smb3_encryption_vector.py
@@ -1,3 +1,9 @@
+#
+# Copyright (c) 2020, Dell Inc. or its subsidiaries.
+# All rights reserved.
+# See file LICENSE for licensing information.
+#
+
 # test vectors from Microsoft openspecification group
 # SMB 3.0 Encryption: https://blogs.msdn.microsoft.com/openspecification/2012/10/05/encryption-in-smb-3-0-a-protocol-perspective/
 # SMB 3.1.1 Encryption: https://blogs.msdn.microsoft.com/openspecification/2015/09/09/smb-3-1-1-encryption-in-windows-10/

--- a/pike/test/tree.py
+++ b/pike/test/tree.py
@@ -1,27 +1,7 @@
 #
-# Copyright (c) 2013, EMC Corporation
+# Copyright (c) 2013-2020, Dell Inc. or its subsidiaries.
 # All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice,
-# this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# See file LICENSE for licensing information.
 #
 # Module Name:
 #

--- a/pike/transport.py
+++ b/pike/transport.py
@@ -13,6 +13,7 @@
 #
 # Authors: Masen Furer (masen.furer@dell.com)
 #
+
 from builtins import object
 from errno import errorcode, EBADF, ECONNRESET, ENOTCONN, ESHUTDOWN, \
                   ECONNABORTED, EISCONN, EINPROGRESS, EALREADY, EWOULDBLOCK, \

--- a/pike/transport.py
+++ b/pike/transport.py
@@ -1,27 +1,7 @@
 #
-# Copyright (c) 2016, Dell Technologies
+# Copyright (c) 2016-2020, Dell Inc. or its subsidiaries.
 # All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice,
-# this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright notice,
-# this list of conditions and the following disclaimer in the documentation
-# and/or other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
+# See file LICENSE for licensing information.
 #
 # Module Name:
 #

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python
+#
+# Copyright (c) 2016-2020, Dell Inc. or its subsidiaries.
+# All rights reserved.
+# See file LICENSE for licensing information.
+#
 
 import ctypes
 import os


### PR DESCRIPTION
Update all code headers referring to licensing information. Make them
consistent.

Add licensing statement to all code and document files.

Add mention of Dell Open Source Program at bottom of README.md.

Clarify which license used in LICENSE file.

Fix PEP8 outer scope newline spacing.

Issue #93