### PR TITLE
QueryInfoResponse can contain multiple children

### DIFF
--- a/.github/workflows/test_samba.yml
+++ b/.github/workflows/test_samba.yml
@@ -26,12 +26,12 @@ jobs:
         - 445/tcp
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       if: "!endsWith(matrix.python-version, '-dev')"
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: deadsnakes/action@v1.0.0
+    - uses: deadsnakes/action@v2.0.2
       if: endsWith(matrix.python-version, '-dev')
       with:
         python-version: ${{ matrix.python-version }}

--- a/pike/model.py
+++ b/pike/model.py
@@ -1628,14 +1628,30 @@ class Channel(object):
                         file_information_class=smb2.FILE_BASIC_INFORMATION,
                         info_type=smb2.SMB2_0_INFO_FILE,
                         output_buffer_length=4096,
-                        additional_information=None):
-        return self.connection.transceive(
+                        additional_information=None,
+                        first_result_only=None):
+        if first_result_only is None:
+            warnings.warn(
+                "In a future release, query_file_info will return QueryInfoResponse "
+                "instead of the first result from QueryInfoResponse. To maintain "
+                "the previous behavior (and silence this warning) pass "
+                "`first_result_only=True`. To opt-in to the new behavior, pass "
+                "`first_result_only=False`, which will become the new default.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            first_result_only = True
+        resp = self.connection.transceive(
                 self.query_file_info_request(
                     create_res,
                     file_information_class,
                     info_type,
                     output_buffer_length,
-                    additional_information).parent.parent)[0][0][0]
+                    additional_information).parent.parent)[0][0]
+        if first_result_only:
+            # only returning the first child info
+            return resp[0]
+        return resp
 
     def set_file_info_request(
             self,

--- a/pike/smb2.py
+++ b/pike/smb2.py
@@ -2130,6 +2130,7 @@ class QueryDirectoryResponse(Response):
 
         # Try to figure out file information class by looking up
         # associated request in context
+        request = None
         context = self.context
 
         if context:

--- a/pike/smb2.py
+++ b/pike/smb2.py
@@ -2285,13 +2285,14 @@ class QueryInfoResponse(Response):
         end = cur + output_buffer_length
 
         key = (self._info_type, self._file_information_class)
-        if key in self._info_map:
-            cls = self._info_map[key]
-            with cur.bounded(cur, end):
-                if cls == FileSecurityInformation:
-                    cls(self, end).decode(cur)
-                else:
-                    cls(self).decode(cur)
+        info_cls = self._info_map.get(key)
+        if info_cls is not None:
+            if info_cls == FileSecurityInformation:
+                info_cls(self, end).decode(cur)
+            else:
+                with cur.bounded(cur, end):
+                    while cur < end:
+                        info_cls(self).decode(cur)
         else:
             Information(self, end).decode(cur)
 
@@ -2828,6 +2829,8 @@ class FileStreamInformation(FileInformation):
         self.stream_size = cur.decode_int64le()
         self.stream_allocation_size = cur.decode_int64le()
         self.stream_name = cur.decode_utf16le(self.stream_name_length)
+        if self.next_entry_offset:
+            cur.advanceto(self.start + self.next_entry_offset)
 
 
 # Compression Format

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,8 @@ def run_setup(with_extensions):
             'enum34~=1.1.6;  python_version ~= "2.7"',
             'attrs~=19.3.0',
             "pycryptodomex",
-            "future"
+            "future",
+            "six",
         ],
         ext_modules=ext_modules,
         test_suite="setup.pike_suite",


### PR DESCRIPTION
* `pike.smb2.QueryInfoResponse` can now correctly read multiple items from the buffer
* `pike.model.Channel.query_file_info` behavior change is pending
  * Future releases will return the `QueryInfoResponse` itself instead of the first child of the response