### PR TITLE
setup.py: do not set an upper bound on python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ def run_setup(with_extensions):
         url="https://github.com/emc-isilon/pike",
         packages=["pike", "pike.test"],
         entry_points={"pytest11": ["pike = pike.pytest_support",]},
-        python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,<3.9",
+        python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*",
         install_requires=[
             'enum34~=1.1.6;  python_version ~= "2.7"',
             'attrs~=19.3.0',


### PR DESCRIPTION
really this should have slid in with #88

discovering the problem now attempting to add pike as a dependency in poetry, which actually cares about satisfying requirements