### PR TITLE
test_samba.yml: pip install pike

### DIFF
--- a/.github/workflows/test_samba.yml
+++ b/.github/workflows/test_samba.yml
@@ -39,7 +39,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - run: python --version --version && which python
     - name: Install Pike
-      run: python setup.py install
+      run: pip install .
     - name: Install pytest
       run: pip install pytest
     - name: Test Pike


### PR DESCRIPTION
avoid `python setup.py` which can't handle extended metadata preventing incompatible packages from being downloaded