### PR TITLE
pike 0.2.27

### DIFF
--- a/pike/__init__.py
+++ b/pike/__init__.py
@@ -13,5 +13,5 @@ __all__ = [
         'test',
         'transport',
 ]
-__version_info__ = (0, 2, 26)
+__version_info__ = (0, 2, 27)
 __version__ = "{0}.{1}.{2}".format(*__version_info__)


### PR DESCRIPTION
Tagging pike 0.2x as 0.2.27 since the need is to make a Kerberos build available for pike based on Python 2 for repos which still use that.

Testing Done

[Test_Results.txt](https://github.com/emc-isilon/pike/files/7332236/Test_Results.txt)


