### PR TITLE
pike.auth: maxsplit=1 for password and domain

### DIFF
--- a/.github/workflows/test_samba.yml
+++ b/.github/workflows/test_samba.yml
@@ -48,6 +48,6 @@ jobs:
         PIKE_PORT: ${{ job.services.samba.ports[445] }}
         PIKE_SHARE: pike
         PIKE_CREDS: pike%GiThubCI123
-      run:
-        - python -m unittest -v pike.test.samba_suite
-        - python -m pytest --pyargs pike.test.internal
+      run: |
+        python -m unittest -v pike.test.samba_suite
+        python -m pytest --pyargs pike.test.internal

--- a/.github/workflows/test_samba.yml
+++ b/.github/workflows/test_samba.yml
@@ -48,4 +48,6 @@ jobs:
         PIKE_PORT: ${{ job.services.samba.ports[445] }}
         PIKE_SHARE: pike
         PIKE_CREDS: pike%GiThubCI123
-      run: python -m unittest -v pike.test.samba_suite
+      run:
+        - python -m unittest -v pike.test.samba_suite
+        - python -m pytest --pyargs pike.test.internal

--- a/pike/auth.py
+++ b/pike/auth.py
@@ -42,9 +42,9 @@ def split_credentials(creds):
             "Pass creds as unicode string, got {!r}".format(creds), UnicodeWarning
         )
         creds = creds.decode("utf-8")
-    user, password = creds.split("%")
+    user, password = creds.split("%", 1)
     if "\\" in user:
-        domain, user = user.split("\\")
+        domain, user = user.split("\\", 1)
     else:
         domain = "NONE"
     return (domain, user, password)

--- a/pike/test/internal/test_auth.py
+++ b/pike/test/internal/test_auth.py
@@ -1,0 +1,23 @@
+import pytest
+
+import pike.auth
+
+
+# pike uses the "NONE" domain when one isn't provided
+NONE = "NONE"
+
+
+@pytest.mark.parametrize(
+    "cred_str,exp_cred_tuple",
+    (
+        ("foo%bar", (NONE, "foo", "bar")),
+        ("foo%ba%r", (NONE, "foo", "ba%r")),
+        ("BAZ\\foo%bar", ("BAZ", "foo", "bar")),
+        ("BAZ\\foo%b%ar", ("BAZ", "foo", "b%ar")),
+        # not convinced this is valid, but it won't crash the splitter
+        ("BA\\Z\\foo%bar", ("BA", "Z\\foo", "bar")),
+        ("BA\\Z\\foo%bar%", ("BA", "Z\\foo", "bar%")),
+    ),
+)
+def test_split_credentials(cred_str, exp_cred_tuple):
+    assert pike.auth.split_credentials(cred_str) == exp_cred_tuple


### PR DESCRIPTION
Avoid multiple splits when the data contains the delimiter.

Fixes #116