### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/test_samba.yml
+++ b/.github/workflows/test_samba.yml
@@ -11,7 +11,7 @@ on: [push, pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       max-parallel: 5
       matrix:

--- a/.github/workflows/test_samba.yml
+++ b/.github/workflows/test_samba.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [2.7, 3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: ["2.7.18", "3.6.15", 3.7, 3.8, 3.9, "3.10", "3.11"]
 
     services:
       samba:


### PR DESCRIPTION
ubuntu-latest moved to 22.04, which dropped support for py27 and py36, which pike still supports.

pin to the latest py27 and py36 versions

pin to previous ubuntu 20.04 for the runner container to keep support