### PR TITLE
Updated test_resiliency_reconnect_before_timeout

### DIFF
--- a/src/pike/test/persistent.py
+++ b/src/pike/test/persistent.py
@@ -148,7 +148,7 @@ class Persistent(test.PikeTest):
     def test_resiliency_reconnect_before_timeout(self):
         handle1 = self.create_persistent()
         self.assertTrue(handle1.is_persistent)
-        timeout = 4000
+        timeout = 10000
         wait_time = timeout / 1000.0 * 0.5
         a = self.channel.network_resiliency_request(handle1, timeout=timeout)
         self.assertTrue(handle1.is_resilient)


### PR DESCRIPTION
---Increased timeout so that test is more resilient to slowness in virtual environment.

Tested locally on CA share

```
PIKE_SERVER=<ip> PIKE_SHARE=<sharename> PIKE_CREDS=<creds> python2 -m unittest pike.test.persistent
........
----------------------------------------------------------------------
Ran 8 tests in 141.545s

OK
```
@sudosantanu @marchhare09