### PR TITLE
Fix setup.py to release based on git tag

### DIFF
--- a/localsetup.py
+++ b/localsetup.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2024, Dell Inc. or its subsidiaries.
+# All rights reserved.
+# See file LICENSE for licensing information.
+#
+import ctypes
+import os
+import subprocess
+
+try:
+    from setuptools import setup, Extension
+except ImportError:
+    from distutils.core import setup, Extension
+from distutils.errors import CCompilerError, DistutilsExecError, DistutilsPlatformError
+
+_HERED = os.path.abspath(os.path.dirname(__file__))
+
+val = subprocess.Popen("git describe", stdout=subprocess.PIPE, shell=True)
+out, err = val.communicate()
+tag = out.decode('utf-8').strip("\n")
+try:
+    libgssapi_krb5 = ctypes.CDLL("libgssapi_krb5.so")
+    defines = [
+        ("HAVE_GSS_SET_CRED_OPTION", hasattr(libgssapi_krb5, "gss_set_cred_option")),
+        (
+            "HAVE_GSSSPI_SET_CRED_OPTION",
+            hasattr(libgssapi_krb5, "gssspi_set_cred_option"),
+        ),
+    ]
+    lw_krb_module = Extension(
+        "pike.kerberos",
+        [
+            "pykerb/base64.c",
+            "pykerb/kerberosbasic.c",
+            "pykerb/kerberos.c",
+            "pykerb/kerberosgss.c",
+            "pykerb/kerberospw.c",
+        ],
+        include_dirs=[os.path.join(_HERED, "pykerb", "vendor")],
+        libraries=["gssapi_krb5"],
+        define_macros=defines,
+    )
+    setup(ext_modules=[lw_krb_module], version=tag)
+except (OSError, CCompilerError, DistutilsExecError, DistutilsPlatformError):
+    print("libgssapi_krb5 not available, skipping kerberos module")
+    setup(version=tag)


### PR DESCRIPTION
This part will help in releasing the package. 
NOTE: localsetup.py is a copy of setup.py with git tag used for release.

Tested by going to pike folder and running

`python3 ./localsetup.py dist`
...
...
Writing pike-smb2-0.4.5/setup.cfg
Creating tar archive

This will be followed by `twine upload dist/pike-smb2-0.4.5.tar.gz`

CC: @sudosantanu @marchhare09 @siddiw @sgovind