### PR TITLE
Update check for ctx to be explicit

### DIFF
--- a/src/pike/io.py
+++ b/src/pike/io.py
@@ -116,8 +116,8 @@ class _Open(object):
         :return: the durable handle timeout in seconds (or None if not durable)
         """
         ctx = self.durable_handle_v2_ctx
-        if ctx:
-            return ctx.durable_timeout
+        if ctx is not None:
+            return ctx.timeout
         elif self._previous_open is not None:
             return self._previous_open.durable_timeout
 
@@ -128,8 +128,8 @@ class _Open(object):
         :return: the durable handle flags (or None if not durable)
         """
         ctx = self.durable_handle_v2_ctx
-        if ctx:
-            return ctx.durable_flags
+        if ctx is not None:
+            return ctx.flags
         elif self._previous_open is not None:
             return self._previous_open.durable_flags
         return 0

--- a/src/pike/test/durable.py
+++ b/src/pike/test/durable.py
@@ -25,6 +25,8 @@ import pike.smb2
 import pike.test
 import pike.ntstatus
 
+MAX_TIMEOUT = 120
+DELAY_TIME = 30
 
 # for buffer too small
 class InvalidNetworkResiliencyRequestRequest(pike.smb2.NetworkResiliencyRequestRequest):
@@ -156,6 +158,33 @@ class DurableHandleTest(pike.test.PikeTest):
         # Reconnect should now fail
         with self.assert_error(pike.ntstatus.STATUS_OBJECT_NAME_NOT_FOUND):
             handle3 = self.create(chan3, tree3, durable=handle1)
+
+    def durable_timer_test(self, durable):
+        chan, tree = self.tree_connect()
+
+        handle1 = self.create(chan, tree, durable=durable)
+        self.assertEqual(handle1.lease.lease_state, self.rwh)
+        self.assertTrue(handle1.is_durable)
+
+        chan.connection.close()
+
+        self.assertTrue(DELAY_TIME < MAX_TIMEOUT)
+        time.sleep(DELAY_TIME)
+
+        chan2, tree2 = self.tree_connect()
+
+        # Request reconnect before max timeout
+        handle2 = self.create(chan2, tree2, durable=handle1)
+        self.assertEqual(handle2.lease.lease_state, self.rwh)
+        chan2.connection.close()
+
+        time.sleep(MAX_TIMEOUT + DELAY_TIME)
+
+        # Request reconnect after max timeout
+        chan3, tree3 = self.tree_connect()
+
+        with self.assert_error(pike.ntstatus.STATUS_OBJECT_NAME_NOT_FOUND):
+            self.create(chan3, tree3, durable=handle1)
 
     @pike.test.RequireDialect(pike.smb2.DIALECT_SMB2_1)
     def test_resiliency_reconnect_before_timeout(self, durable=True):
@@ -329,3 +358,7 @@ class DurableHandleTest(pike.test.PikeTest):
     @pike.test.RequireDialect(pike.smb2.DIALECT_SMB3_0)
     def test_durable_v2_invalidate(self):
         self.durable_invalidate_test(0)
+
+    @pike.test.RequireDialect(pike.smb2.DIALECT_SMB3_0)
+    def test_durable_v2_timer(self):
+        self.durable_timer_test(0)


### PR DESCRIPTION
This updates the check for ctx to be explicit. Ctx is also of type DurableHandleV2Response which has an attribute named timeout rather than durable_timeout. 

Before: 
```
root@DTRDUC3599532:~/pike/src [master %] # PIKE_SERVER="10.224.9.239" PIKE_SHARE="ifs" PIKE_CREDS=root%a python3 -m unittest pike.test.durable.DurableHandleTest.test_durable_v2_invalidate
F
======================================================================
FAIL: test_durable_v2_invalidate (pike.test.durable.DurableHandleTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/root/pike/src/pike/test/durable.py", line 331, in test_durable_v2_invalidate
    self.durable_invalidate_test(0)
  File "/root/pike/src/pike/test/durable.py", line 158, in durable_invalidate_test
    handle3 = self.create(chan3, tree3, durable=handle1)
  File "/usr/lib64/python3.6/contextlib.py", line 88, in __exit__
    next(self.gen)
  File "/root/pike/src/pike/test/__init__.py", line 546, in assert_error
    raise self.failureException('No error raised when "%s" expected' % status)
AssertionError: No error raised when "STATUS_OBJECT_NAME_NOT_FOUND" expected

----------------------------------------------------------------------
Ran 1 test in 0.144s

FAILED (failures=1)
root@DTRDUC3599532:~/pike/src [master %] # PIKE_SERVER="10.224.9.239" PIKE_SHARE="ifs" PIKE_CREDS=root%a python3 -m unittest pike.test.durable.DurableHandleTest.test_durable_reconnect_v2_fails_client_guid
F
======================================================================
FAIL: test_durable_reconnect_v2_fails_client_guid (pike.test.durable.DurableHandleTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/root/pike/src/pike/test/durable.py", line 324, in test_durable_reconnect_v2_fails_client_guid
    self.durable_reconnect_fails_client_guid_test(0)
  File "/root/pike/src/pike/test/durable.py", line 117, in durable_reconnect_fails_client_guid_test
    handle2 = self.create(chan2, tree2, durable=handle1)
  File "/usr/lib64/python3.6/contextlib.py", line 88, in __exit__
    next(self.gen)
  File "/root/pike/src/pike/test/__init__.py", line 546, in assert_error
    raise self.failureException('No error raised when "%s" expected' % status)
AssertionError: No error raised when "STATUS_OBJECT_NAME_NOT_FOUND" expected

----------------------------------------------------------------------
Ran 1 test in 0.116s

FAILED (failures=1)
 root@DTRDUC3596981:~ # PIKE_SERVER="10.224.9.239" PIKE_SHARE="ifs" PIKE_CREDS=root%a python3 -m unittest pike.test.persistent
FFFFFFFF
======================================================================
FAIL: test_buffer_too_small (pike.test.persistent.Persistent)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib64/python3.6/site-packages/pike/test/persistent.py", line 233, in test_buffer_too_small
    handle1 = self.create_persistent()
  File "/usr/local/lib64/python3.6/site-packages/pike/test/persistent.py", line 65, in create_persistent
    self.assertEqual(handle.durable_flags, smb2.SMB2_DHANDLE_FLAG_PERSISTENT)
AssertionError: 0 != SMB2_DHANDLE_FLAG_PERSISTENT
....
```
After:
```
root@DTRDUC3599532:~/pike/src [BR_SLAM_DH] # PIKE_SERVER="10.224.9.239" PIKE_SHARE="ifs" PIKE_CREDS=root%a python3 -m unittest pike.test.durable.DurableHandleTest.test_durable_v2_invalidate
.
----------------------------------------------------------------------
Ran 1 test in 0.158s

OK
root@DTRDUC3599532:~/pike/src [BR_SLAM_DH] # PIKE_SERVER="10.224.9.239" PIKE_SHARE="ifs" PIKE_CREDS=root%a python3 -m unittest pike.test.durable.DurableHandleTest.test_durable_reconnect_v2_fails_client_guid
.
----------------------------------------------------------------------
Ran 1 test in 0.144s

OK
root@DTRDUC3599532:~/pike/src [BR_SLAM_DH] # PIKE_SERVER="10.224.9.239" PIKE_SHARE="ifs" PIKE_CREDS=root%a python3 -m unittest pike.test.persistent
........
----------------------------------------------------------------------
Ran 8 tests in 130.050s

OK
```
New test:
```
root@DTRDUC3599532:~/pike/src [BR_SLAM_DH] # PIKE_SERVER="10.224.9.239" PIKE_SHARE="ifs" PIKE_CREDS=root%a python3 -m unittest pike.test.durable.DurableHandleTest.test_durable_v2_timer
.
----------------------------------------------------------------------
Ran 1 test in 180.231s

OK
```