### PR TITLE
Fix deprecated GitHub actions

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -14,8 +14,9 @@ jobs:
         run: python -m pip install cibuildwheel==2.11.3
       - name: Build wheels
         run: ./samba/dc.sh ./build_and_test_wheels.sh
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: wheels-py3
           path: ./wheelhouse/*.whl
 
   build_wheels_py27:
@@ -27,8 +28,9 @@ jobs:
       - run: sudo apt-get update && sudo apt-get install python2.7
       - name: Build wheels
         run: ./samba/dc.sh ./build_and_test_wheels27.sh
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: wheels-py27
           path: ./wheelhouse/*.whl
 
   build_sdist:
@@ -40,8 +42,9 @@ jobs:
       - name: Build sdist
         run: pipx run build --sdist
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: sdist
           path: dist/*.tar.gz
 
   upload_pypi:
@@ -50,12 +53,13 @@ jobs:
     # upload to PyPI on every tag starting with 'v'
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: artifact
+          pattern: '*'
           path: dist
+          merge-multiple: true
 
-      - uses: pypa/gh-action-pypi-publish@v1.5.0
+      - uses: pypa/gh-action-pypi-publish@v1.14.0
         with:
           user: ${{ secrets.PYPI_USERNAME }}
           password: ${{ secrets.PYPI_PASSWORD }}

--- a/src/pike/io.py
+++ b/src/pike/io.py
@@ -116,8 +116,8 @@ class _Open(object):
         :return: the durable handle timeout in seconds (or None if not durable)
         """
         ctx = self.durable_handle_v2_ctx
-        if ctx:
-            return ctx.durable_timeout
+        if ctx is not None:
+            return ctx.timeout
         elif self._previous_open is not None:
             return self._previous_open.durable_timeout
 
@@ -128,8 +128,8 @@ class _Open(object):
         :return: the durable handle flags (or None if not durable)
         """
         ctx = self.durable_handle_v2_ctx
-        if ctx:
-            return ctx.durable_flags
+        if ctx is not None:
+            return ctx.flags
         elif self._previous_open is not None:
             return self._previous_open.durable_flags
         return 0

--- a/src/pike/model.py
+++ b/src/pike/model.py
@@ -1468,7 +1468,11 @@ class Channel(object):
                 durable_req = smb2.DurableHandleReconnectV2Request(create_req)
                 durable_req.file_id = durable.file_id
                 durable_req.create_guid = durable.create_guid
-                durable_req.flags = durable.durable_flags
+                # Changed here to allow explicit setting of Persistent flag for negative
+                # tests, ideally it should be as per open.durable_flags as below
+                # durable_req.flags = durable.durable_flags
+                if persistent is True:
+                    durable_req.flags = smb2.SMB2_DHANDLE_FLAG_PERSISTENT | durable.durable_flags
         elif durable is True:
             durable_req = smb2.DurableHandleRequest(create_req)
         elif durable is not False:

--- a/src/pike/test/durable.py
+++ b/src/pike/test/durable.py
@@ -19,14 +19,14 @@ from builtins import map
 import array
 import random
 import time
+import unittest
 
 import pike.model
 import pike.smb2
 import pike.test
 import pike.ntstatus
 
-MAX_TIMEOUT = 120
-DELAY_TIME = 30
+DELAY_TIME = 10
 
 # for buffer too small
 class InvalidNetworkResiliencyRequestRequest(pike.smb2.NetworkResiliencyRequestRequest):
@@ -239,7 +239,12 @@ class DurableHandleTest(pike.test.PikeTest):
 
         chan.connection.close()
 
-        self.assertTrue(DELAY_TIME < MAX_TIMEOUT)
+        # Convert durable timeout from milliseconds to seconds
+        timeout = handle1.durable_timeout/1000
+
+        if (DELAY_TIME >= timeout):
+             raise unittest.SkipTest("Durable timeout needs to be greater than 10 seconds. Skipping...")
+
         time.sleep(DELAY_TIME)
 
         chan2, tree2 = self.tree_connect()
@@ -247,9 +252,10 @@ class DurableHandleTest(pike.test.PikeTest):
         # Request reconnect before max timeout
         handle2 = self.create(chan2, tree2, durable=handle1)
         self.assertEqual(handle2.lease.lease_state, self.rwh)
+        self.assertEqual(handle1.durable_timeout, handle2.durable_timeout)
         chan2.connection.close()
 
-        time.sleep(MAX_TIMEOUT + DELAY_TIME)
+        time.sleep(timeout + DELAY_TIME)
 
         # Request reconnect after max timeout
         chan3, tree3 = self.tree_connect()

--- a/src/pike/test/durable.py
+++ b/src/pike/test/durable.py
@@ -71,6 +71,7 @@ class DurableHandleTest(pike.test.PikeTest):
             lease_key=lease_key,
             lease_state=lease,
             durable=durable,
+            persistent=False
         ).result()
 
     def durable_test(self, durable):
@@ -101,6 +102,76 @@ class DurableHandleTest(pike.test.PikeTest):
         self.assertEqual(handle2.lease.lease_state, self.rwh)
         self.assertTrue(handle2.is_durable)
         chan2.close(handle2)
+
+    # Persistent flag IS set in RECONNECT
+    # MS SMB Spec 3.3.5.9.12
+    # If Open.IsPersistent is FALSE and the SMB2_DHANDLE_FLAG_PERSISTENT bit
+    # is set in the Flags field of the SMB2_CREATE_DURABLE_HANDLE_RECONNECT_V2
+    # Create Context, the server SHOULD<349> fail the request with STATUS_INVALID_PARAMETER. 
+    def durable_reconnect_test_fails(self, durable):
+        chan, tree = self.tree_connect()
+
+        handle1 = self.create(chan, tree, durable=durable)
+
+        self.assertEqual(handle1.lease.lease_state, self.rwh)
+        self.assertTrue(handle1.is_durable)
+
+        # Close the connection
+        chan.connection.close()
+
+        chan2, tree2 = self.tree_connect()
+
+        with self.assert_error(pike.ntstatus.STATUS_INVALID_PARAMETER):
+            handle2 = chan2.create(
+                tree2,
+                "durable.txt",
+                access=pike.smb2.FILE_READ_DATA
+                | pike.smb2.FILE_WRITE_DATA
+                | pike.smb2.DELETE,
+                share=self.share_all,
+                disposition=pike.smb2.FILE_SUPERSEDE,
+                oplock_level=pike.smb2.SMB2_OPLOCK_LEVEL_LEASE,
+                lease_key=self.lease1,
+                lease_state=self.rwh,
+                durable=handle1,
+                persistent=True
+            ).result()
+
+    # RECONNECT (V1) sent for a non-durable Open.
+    # MS SMB Spec 3.3.5.9.12
+    # Open.IsDurable is FALSE and Open.IsResilient is FALSE or unimplemented. 
+    def durable_reconnect_without_durable_open(self, durable):
+        chan, tree = self.tree_connect()
+
+        handle1 = chan.create(
+            tree,
+            "non_durable.txt",
+            access=pike.smb2.FILE_READ_DATA
+            | pike.smb2.FILE_WRITE_DATA
+            | pike.smb2.DELETE,
+            share=self.share_all,
+            disposition=pike.smb2.FILE_SUPERSEDE
+        ).result()
+
+        self.assertFalse(handle1.is_durable)
+
+        # Close the connection
+        chan.connection.close()
+
+        chan2, tree2 = self.tree_connect()
+
+        with self.assert_error(pike.ntstatus.STATUS_OBJECT_NAME_NOT_FOUND):
+            handle2 = chan2.create(
+                tree2,
+                "non_durable.txt",
+                access=pike.smb2.FILE_READ_DATA
+                | pike.smb2.FILE_WRITE_DATA
+                | pike.smb2.DELETE,
+                share=self.share_all,
+                disposition=pike.smb2.FILE_SUPERSEDE,
+                durable=handle1,
+                persistent=0
+            ).result()
 
     def durable_reconnect_fails_client_guid_test(self, durable):
         chan, tree = self.tree_connect()
@@ -344,6 +415,16 @@ class DurableHandleTest(pike.test.PikeTest):
     @pike.test.RequireDialect(pike.smb2.DIALECT_SMB3_0)
     def test_durable_reconnect_v2(self):
         self.durable_reconnect_test(0)
+
+    # Reconnect a durable handle via V2 context structure
+    @pike.test.RequireDialect(pike.smb2.DIALECT_SMB3_0)
+    def test_durable_reconnect_v2_fails(self):
+        self.durable_reconnect_test_fails(0)
+
+    # Reconnect a durable handle via V2 context structure
+    @pike.test.RequireDialect(pike.smb2.DIALECT_SMB3_0)
+    def test_durable_reconnect_without_durable_open(self):
+        self.durable_reconnect_without_durable_open(0)
 
     # Reconnecting a durable handle (v2) after a TCP disconnect
     # fails with STATUS_OBJECT_NAME_NOT_FOUND if the client

--- a/src/pike/test/durable.py
+++ b/src/pike/test/durable.py
@@ -25,6 +25,8 @@ import pike.smb2
 import pike.test
 import pike.ntstatus
 
+MAX_TIMEOUT = 120
+DELAY_TIME = 30
 
 # for buffer too small
 class InvalidNetworkResiliencyRequestRequest(pike.smb2.NetworkResiliencyRequestRequest):
@@ -156,6 +158,33 @@ class DurableHandleTest(pike.test.PikeTest):
         # Reconnect should now fail
         with self.assert_error(pike.ntstatus.STATUS_OBJECT_NAME_NOT_FOUND):
             handle3 = self.create(chan3, tree3, durable=handle1)
+
+    def durable_timer_test(self, durable):
+        chan, tree = self.tree_connect()
+
+        handle1 = self.create(chan, tree, durable=durable)
+        self.assertEqual(handle1.lease.lease_state, self.rwh)
+        self.assertTrue(handle1.is_durable)
+
+        chan.connection.close()
+
+        self.assertTrue(DELAY_TIME < MAX_TIMEOUT)
+        time.sleep(DELAY_TIME)
+
+        chan2, tree2 = self.tree_connect()
+
+        # Request reconnect before max timeout
+        handle2 = self.create(chan2, tree2, durable=handle1)
+        self.assertEqual(handle2.lease.lease_state, self.rwh)
+        chan2.connection.close()
+
+        time.sleep(MAX_TIMEOUT + DELAY_TIME)
+
+        # Request reconnect after max timeout
+        chan3, tree3 = self.tree_connect()
+
+        with self.assert_error(pike.ntstatus.STATUS_OBJECT_NAME_NOT_FOUND):
+            self.create(chan3, tree3, durable=handle1)
 
     @pike.test.RequireDialect(pike.smb2.DIALECT_SMB2_1)
     def test_resiliency_reconnect_before_timeout(self, durable=True):
@@ -329,3 +358,7 @@ class DurableHandleTest(pike.test.PikeTest):
     @pike.test.RequireDialect(pike.smb2.DIALECT_SMB3_0)
     def test_durable_v2_invalidate(self):
         self.durable_invalidate_test(0)
+
+    @pike.test.RequireDialect(pike.smb2.DIALECT_SMB3_0)
+    def test_durable_v2_timer(self):
+        self.durable_timer_test(0)

--- a/src/pike/test/persistent.py
+++ b/src/pike/test/persistent.py
@@ -47,11 +47,11 @@ class Persistent(test.PikeTest):
         self.lease_key = array.array("B", map(random.randint, [0] * 16, [255] * 16))
         self.channel, self.tree = self.tree_connect()
 
-    def create_persistent(self, prev_handle=0):
+    def create_persistent(self, prev_handle=0, path="persistent.txt"):
         """Helper to create a persistent handle, optionally reconnecting an old one"""
         handle = self.channel.create(
             self.tree,
-            "persistent.txt",
+            path,
             access=smb2.FILE_READ_DATA | smb2.FILE_WRITE_DATA | smb2.DELETE,
             share=SHARE_ALL,
             disposition=smb2.FILE_OPEN_IF,
@@ -84,6 +84,41 @@ class Persistent(test.PikeTest):
         self.assertEqual(handle2.lease.lease_state, LEASE_RWH)
 
         self.channel.close(handle2)
+
+    # Persistent flag not set in RECONNECT
+    # MS SMB Spec 3.3.5.9.12
+    # If Open.IsPersistent is TRUE and the SMB2_DHANDLE_FLAG_PERSISTENT bit is not set
+    # in the Flags field of the SMB2_CREATE_DURABLE_HANDLE_RECONNECT_V2 Create Context,
+    # the server SHOULD<347> fail the request with STATUS_OBJECT_NAME_NOT_FOUND. 
+    def test_reconnect_fails(self):
+        # Do a regular persistent open, drop connection, reconnect
+        path = "persistent_fails.txt"
+        handle1 = self.create_persistent(path=path)
+        self.channel.connection.close()
+        self.channel, self.tree = self.tree_connect()
+
+        with self.assert_error(pike.ntstatus.STATUS_OBJECT_NAME_NOT_FOUND):
+            # While sending this RECONNECT, do not set the Persistent flag
+            handle2 = self.channel.create(
+                self.tree,
+                path,
+                access=smb2.FILE_READ_DATA | smb2.FILE_WRITE_DATA | smb2.DELETE,
+                share=SHARE_ALL,
+                disposition=smb2.FILE_OPEN_IF,
+                options=smb2.FILE_DELETE_ON_CLOSE,
+                oplock_level=smb2.SMB2_OPLOCK_LEVEL_LEASE,
+                lease_key=self.lease_key,
+                lease_state=LEASE_RWH,
+                durable=handle1,
+                persistent=False,    # explicitly setting persistent flag to False
+            ).result()
+
+        # Clean up: Reconnect and close file (handle)
+        self.channel.connection.close()
+        self.channel, self.tree = self.tree_connect()
+        handle3 = self.create_persistent(prev_handle=handle1, path=path)
+        self.assertEqual(handle1.file_id, handle3.file_id)
+        self.channel.close(handle3)
 
     # Opening a file with a disconnected persistent handle fails with
     # STATUS_FILE_NOT_AVAILABLE


### PR DESCRIPTION

    Update GitHub Actions to fix deprecation warnings and security alert

    - Upgrade actions/upload-artifact from v3 to v4
    - Upgrade actions/download-artifact from v3 to v4
    - Upgrade pypa/gh-action-pypi-publish from v1.5.0 to v1.14.0

    The v4 artifact actions require unique names for each upload and
    explicit merging when downloading multiple artifacts. Added unique
    names (wheels-py3, wheels-py27, sdist) and merge-multiple flag to
    maintain existing behavior.

    The pypi-publish upgrade addresses Dependabot security alerts.