### PR TITLE
Update GitHub Actions to fix deprecation warnings and security alert

### DIFF
--- a/.github/workflows/test_samba.yml
+++ b/.github/workflows/test_samba.yml
@@ -1,6 +1,4 @@
-# Copyright (c) 2020, Dell Inc. or its subsidiaries.
-# All rights reserved.
-# See file LICENSE for licensing information.
+# Copyright (c) Dell Inc. or its subsidiaries.  All Rights Reserved.
 #
 # Reference: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions (https://archive.vn/1aWt2)
 ---
@@ -11,11 +9,11 @@ on: [push, pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       max-parallel: 5
       matrix:
-        python-version: ["3.6.15", 3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.8, 3.9, "3.10", "3.11"]
 
     services:
       samba:
@@ -42,32 +40,3 @@ jobs:
         PIKE_SHARE: pike
         PIKE_CREDS: pike%GiThubCI123
       run: tox -- -m 'not nosamba'
-
-  # python2.7 is no longer supported by actions/setup-python
-  build_legacy:
-
-    runs-on: ubuntu-20.04
-
-    services:
-      samba:
-        image: dperson/samba@sha256:2d94eb73e10402751afff19af10d3ad91014b137843bdd960bb39f4188acdcfa
-        env:
-          USER: pike;GiThubCI123
-          SHARE: pike;/share;;no;no;;pike;;
-        ports:
-          # will assign a random free host port
-          - 445/tcp
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: "Install python2.7"
-      run: sudo apt-get update && sudo apt-get install python2.7 && curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python2.7
-    - name: Install dependencies
-      run: python2 -m pip install tox
-    - name: Test Pike
-      env:
-        PIKE_SERVER: 127.0.0.1
-        PIKE_PORT: ${{ job.services.samba.ports[445] }}
-        PIKE_SHARE: pike
-        PIKE_CREDS: pike%GiThubCI123
-      run: tox -e py27 -- -m 'not nosamba'

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,3 +1,5 @@
+# Copyright (c) Dell Inc. or its subsidiaries.  All Rights Reserved.
+
 name: Build and Publish Wheels
 
 on: [push, pull_request]
@@ -14,21 +16,9 @@ jobs:
         run: python -m pip install cibuildwheel==2.11.3
       - name: Build wheels
         run: ./samba/dc.sh ./build_and_test_wheels.sh
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          path: ./wheelhouse/*.whl
-
-  build_wheels_py27:
-    name: Build py27 wheel on ubuntu-22.04
-    runs-on: ubuntu-22.04
-
-    steps:
-      - uses: actions/checkout@v3
-      - run: sudo apt-get update && sudo apt-get install python2.7
-      - name: Build wheels
-        run: ./samba/dc.sh ./build_and_test_wheels27.sh
-      - uses: actions/upload-artifact@v3
-        with:
+          name: wheels-py3
           path: ./wheelhouse/*.whl
 
   build_sdist:
@@ -40,22 +30,24 @@ jobs:
       - name: Build sdist
         run: pipx run build --sdist
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: sdist
           path: dist/*.tar.gz
 
   upload_pypi:
-    needs: [build_wheels, build_wheels_py27, build_sdist]
+    needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
     # upload to PyPI on every tag starting with 'v'
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: artifact
+          pattern: '*'
           path: dist
+          merge-multiple: true
 
-      - uses: pypa/gh-action-pypi-publish@v1.5.0
+      - uses: pypa/gh-action-pypi-publish@v1.14.0
         with:
           user: ${{ secrets.PYPI_USERNAME }}
           password: ${{ secrets.PYPI_PASSWORD }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,14 +19,11 @@ classifiers =
     Intended Audience :: Developers
     Topic :: Software Development :: Testing
     Programming Language :: Python
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: Implementation :: CPython
     Operating System :: OS Independent
     Environment :: Console
@@ -34,13 +31,11 @@ classifiers =
 
 [options]
 install_requires =
-    enum34~=1.1.6;  python_version ~= "2.7"
-    pathlib2~=2.3.5;  python_version ~= "2.7"
     attrs >= 19.3
     future
     pycryptodome
     six
-python_requires = >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*
+python_requires = >=3.8
 package_dir=
     =src
 packages = find:

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (c) 2016-2020, Dell Inc. or its subsidiaries.
-# All rights reserved.
-# See file LICENSE for licensing information.
+# Copyright (c) Dell Inc. or its subsidiaries.  All Rights Reserved.
 #
 import ctypes
 import os

--- a/tox.ini
+++ b/tox.ini
@@ -1,25 +1,17 @@
 [tox]
-envlist = py27,py36,py37,py38,py39,py310,py311
+envlist = py38,py39,py310,py311
 passenv = SSH_AUTH_SOCK
 isolated_build = True
 
 [testenv]
 passenv = PIKE_*
 deps =
-    py36: coverage~=5.5
-    !py36: coverage~=6.5
-    py36: pytest-randomly ~= 3.10.0
-    !py36: pytest-randomly ~= 3.12.0
+    coverage~=6.5
+    pytest-randomly ~= 3.12.0
     pytest-rerunfailures ~= 10.2
 commands =
     coverage run -m unittest pike.test.samba_suite
     coverage run -m pytest -ra {posargs}
-
-[testenv:py27]
-deps =
-    coverage~=5.5
-    pytest-randomly ~= 1.2.3
-    pytest-rerunfailures ~= 8.0
 
 [testenv:docs]
 deps =
@@ -56,9 +48,6 @@ commands =
 
 [gh-actions]
 python =
-    2.7: py27
-    3.6: py36
-    3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310


### PR DESCRIPTION
## Summary
Update GitHub Actions to fix deprecation warnings and security alerts, and drop support for EOL Python versions.

## GitHub Actions Updates
- Upgrade `actions/upload-artifact` from v3 to v4
- Upgrade `actions/download-artifact` from v3 to v4
- Upgrade `pypa/gh-action-pypi-publish` from v1.5.0 to v1.14.0
- Update runners from `ubuntu-20.04` to `ubuntu-22.04`
- Standardize copyright headers across workflow files

The v4 artifact actions require unique names for each upload and explicit merging when downloading multiple artifacts.Added unique artifact names (`wheels-py3`, `sdist`) and `merge-multiple: true` flag to maintain existing behavior.

The pypi-publish upgrade addresses Dependabot security alerts.

## Python Version Updates
- **Dropped support** for Python 2.7 (EOL since 2020), 3.6, and 3.7
- Test matrix: **3.8, 3.9, 3.10, 3.11**
- Removed `build_legacy` and `build_wheels_py27` jobs
- Updated `tox.ini` envlist and gh-actions mappings
- Updated `setup.cfg`: removed Python 2.7 dependencies (`enum34`, `pathlib2`), updated classifiers and `python_requires` to `>=3.8`

## Future Work
Python 3.12+ support is deferred to a future PR. The `pike/path.py` module relies on private pathlib internals (`_WindowsFlavour`) that were removed in Python 3.12, requiring a more substantial refactor.