### PR TITLE
Upgrade actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/test_samba.yml
+++ b/.github/workflows/test_samba.yml
@@ -26,8 +26,8 @@ jobs:
           - 445/tcp
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - run: python --version && which python

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.11.3
       - name: Build wheels
@@ -25,7 +25,7 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Build sdist
         run: pipx run build --sdist


### PR DESCRIPTION
Node.js 20 actions are deprecated and will be forced to Node.js 24 starting June 16th, 2026. Update all actions to Node.js 24 compatible versions:
- actions/checkout: v2/v3 -> v6
- actions/setup-python: v3/v4 -> v6