### PR TITLE
Upgrade artifact actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -12,11 +12,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.11.3
       - name: Build wheels
         run: ./samba/dc.sh ./build_and_test_wheels.sh
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: wheels-py3
           path: ./wheelhouse/*.whl
@@ -30,7 +32,7 @@ jobs:
       - name: Build sdist
         run: pipx run build --sdist
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: sdist
           path: dist/*.tar.gz
@@ -41,7 +43,7 @@ jobs:
     # upload to PyPI on every tag starting with 'v'
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           pattern: '*'
           path: dist


### PR DESCRIPTION
- actions/upload-artifact: v4 -> v6
- actions/download-artifact: v4 -> v7

Node.js 20 actions are deprecated and will be forced to Node.js 24 starting June 16th, 2026.